### PR TITLE
Add components availability history link

### DIFF
--- a/index.md
+++ b/index.md
@@ -29,6 +29,7 @@ PRs against [rust-lang/rust-forge].
 * [The current PR testing queue](https://buildbot2.rust-lang.org/homu/queue/rust)
 * [The PR queue over time](https://rust-lang-nursery.github.io/rustc-pr-tracking/)
 * [Toolstate (rls, rustfmt, clippy)](https://rust-lang-nursery.github.io/rust-toolstate/)
+* [Components availability history](https://rust-lang.github.io/rustup-components-history/index.html)
 * [Release history](releases.html). Links to previous release artifacts.
 * [Platform support](platform-support.html).
 * [Release process](release-process.html). How to make releases of Rust.


### PR DESCRIPTION
Some details on this dashboard: https://www.reddit.com/r/rust/comments/9erknj/rustup_components_history/