### PR TITLE
Setup redirects for moved pages

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<!-- page last generated {{ site.time }} -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Redirecting...</title>
+    <meta http-equiv="refresh" content="0;URL='{{ page.destination }}'">
+    <meta rel="canonical" href="{{ page.destination }}">
+    <script type="text/javascript">
+      location.href = "{{ page.destination }}";
+    </script>
+  </head>
+  <body>
+      <p>If you're not redirected <a href="{{ page.destination }}">click here</a>.</p>
+      {{ content }}
+  </body>
+</html>

--- a/debugging.md
+++ b/debugging.md
@@ -1,0 +1,6 @@
+---
+layout: redirect
+destination: https://rust-lang.github.io/rustc-guide/compiler-debugging.html
+---
+
+This page has been moved to the rustc guide.

--- a/stabilization-guide.md
+++ b/stabilization-guide.md
@@ -1,0 +1,6 @@
+---
+layout: redirect
+destination: https://rust-lang.github.io/rustc-guide/stabilization_guide.html
+---
+
+This page has been moved to the rustc guide.

--- a/x-py.md
+++ b/x-py.md
@@ -1,0 +1,6 @@
+---
+layout: redirect
+destination: https://rust-lang.github.io/rustc-guide/how-to-build-and-run.html
+---
+
+This page has been moved to the rustc guide.


### PR DESCRIPTION
This PR adds redirects for the pages moved to the rustc guide, to avoid breaking links.

cc @Centril @RalfJung who reported the issue on Zulip
cc @mark-i-m, we'll want to do this for every page we move out of the forge
fixes #182 