### PR TITLE
Fix Floating Point Bug in Release Number/Date

### DIFF
--- a/index.md
+++ b/index.md
@@ -58,7 +58,7 @@ PRs against [rust-lang/rust-forge].
     var epochDate = moment.utc("2015-12-10");
     var epochRelease = 5;
 
-    var newReleases = moment.utc().diff(epochDate, "weeks") / 6;
+    var newReleases = Math.floor(moment.utc().diff(epochDate, "weeks") / 6);
 
     function addRelease(kind, incr) {
         var releaseNumber = epochRelease + newReleases + incr;


### PR DESCRIPTION
It seems that @kennytm and @pietroalbini last discussed this code in PR rust-lang/rust-forge#207. 

Are they the appropriate reviewers for this PR?

The whole story is in the commit message, as follows:

I came across The Rust Forge web page at https://forge.rust-lang.org on
March 6th 2019 and found myself looking at a very puzzling number for
the current stable release, "1.33.16666666666667", with a release date
of "March 7th 2019".

From rust-lang/rust/RELEASES.md, the page should have stated "1.33" and
"February 28th 2019". Predicted releases were similarly inaccurate.

I fixed the above bug by using `Math.floor` (rounding down) when
calculating `newReleases`, the number of 6 week periods since the epoch.

(It appeared that, from the uses of `newReleases`, it was intended to be
an integer value.)

I checked that the fixed calculation generated correct release numbers
and correct dates in 6 week increments from 2019-02-28.