### PR TITLE
Update platform support

### DIFF
--- a/platform-support.md
+++ b/platform-support.md
@@ -48,74 +48,74 @@ these platforms are required to have each of the following:
   platforms **building**. For some platforms only the standard library is
   compiled, but for others `rustc` and `cargo` are too.
 
-|  Target                           | std |rustc|cargo| notes                               |
-|-----------------------------------|-----|-----|-----|-------------------------------------|
-| `aarch64-apple-ios`               |  ✓  |     |     | ARM64 iOS                           |
-| `aarch64-fuchsia`                 |  ✓  |     |     | ARM64 Fuchsia                       |
-| `aarch64-linux-android`           |  ✓  |     |     | ARM64 Android                       |
-| `aarch64-unknown-linux-gnu`       |  ✓  |  ✓  |  ✓  | ARM64 Linux                         |
-| `aarch64-unknown-linux-musl`      |  ✓  |     |     | ARM64 Linux with MUSL               |
-| `aarch64-pc-windows-msvc`         |  ✓  |     |     | ARM64 Windows MSVC                  |
-| `arm-linux-androideabi`           |  ✓  |     |     | ARMv7 Android                       |
-| `arm-unknown-linux-gnueabi`       |  ✓  |  ✓  |  ✓  | ARMv6 Linux                         |
-| `arm-unknown-linux-gnueabihf`     |  ✓  |  ✓  |  ✓  | ARMv6 Linux, hardfloat              |
-| `arm-unknown-linux-musleabi`      |  ✓  |     |     | ARMv6 Linux with MUSL               |
-| `arm-unknown-linux-musleabihf`    |  ✓  |     |     | ARMv6 Linux, MUSL, hardfloat        |
-| `armebv7r-none-eabi`              |  *  |     |     | Bare ARMv7-R, Big Endian            |
-| `armebv7r-none-eabihf`            |  *  |     |     | Bare ARMv7-R, Big Endian, hardfloat |
-| `armv5te-unknown-linux-gnueabi`   |  ✓  |     |     | ARMv5TE Linux                       |
-| `armv5te-unknown-linux-musleabi`  |  ✓  |     |     | ARMv5TE Linux with MUSL             |
-| `armv7-apple-ios`                 |  ✓  |     |     | ARMv7 iOS, Cortex-A8                |
-| `armv7-linux-androideabi`         |  ✓  |     |     | ARMv7a Android                      |
-| `armv7-unknown-linux-gnueabihf`   |  ✓  |  ✓  |  ✓  | ARMv7 Linux                         |
-| `armv7-unknown-linux-musleabihf`  |  ✓  |     |     | ARMv7 Linux with MUSL               |
-| `armv7r-none-eabi`                |  ✓  |     |     | Bare ARMv7-R,                       |
-| `armv7r-none-eabihf`              |  ✓  |     |     | Bare ARMv7-R, hardfloat             |
-| `armv7s-apple-ios`                |  ✓  |     |     | ARMv7 iOS, Cortex-A9                |
-| `asmjs-unknown-emscripten`        |  ✓  |     |     | asm.js via Emscripten               |
-| `i386-apple-ios`                  |  ✓  |     |     | 32-bit x86 iOS                      |
-| `i586-pc-windows-msvc`            |  ✓  |     |     | 32-bit Windows w/o SSE              |
-| `i586-unknown-linux-gnu`          |  ✓  |     |     | 32-bit Linux w/o SSE                |
-| `i586-unknown-linux-musl`         |  ✓  |     |     | 32-bit Linux w/o SSE, MUSL          |
-| `i686-linux-android`              |  ✓  |     |     | 32-bit x86 Android                  |
-| `i686-unknown-freebsd`            |  ✓  |  ✓  |  ✓  | 32-bit FreeBSD                      |
-| `i686-unknown-linux-musl`         |  ✓  |     |     | 32-bit Linux with MUSL              |
-| `mips-unknown-linux-gnu`          |  ✓  |  ✓  |  ✓  | MIPS Linux                          |
-| `mips-unknown-linux-musl`         |  ✓  |     |     | MIPS Linux with MUSL                |
-| `mips64-unknown-linux-gnuabi64`   |  ✓  |  ✓  |  ✓  | MIPS64 Linux, n64 ABI               |
-| `mips64el-unknown-linux-gnuabi64` |  ✓  |  ✓  |  ✓  | MIPS64 (LE) Linux, n64 ABI          |
-| `mipsel-unknown-linux-gnu`        |  ✓  |  ✓  |  ✓  | MIPS (LE) Linux                     |
-| `mipsel-unknown-linux-musl`       |  ✓  |     |     | MIPS (LE) Linux with MUSL           |
-| `powerpc-unknown-linux-gnu`       |  ✓  |  ✓  |  ✓  | PowerPC Linux                       |
-| `powerpc64-unknown-linux-gnu`     |  ✓  |  ✓  |  ✓  | PPC64 Linux                         |
-| `powerpc64le-unknown-linux-gnu`   |  ✓  |  ✓  |  ✓  | PPC64LE Linux                       |
-| `riscv32imac-unknown-none-elf`    |  *  |     |     | Bare RISC-V (RV32IMAC ISA)          |
-| `riscv32imc-unknown-none-elf`     |  *  |     |     | Bare RISC-V (RV32IMC ISA)           |
-| `riscv64gc-unknown-none-elf`      |  *  |     |     | Bare RISC-V (RV64IMAFDC ISA)        |
-| `riscv64imac-unknown-none-elf`    |  *  |     |     | Bare RISC-V (RV64IMAC ISA)          |
-| `s390x-unknown-linux-gnu`         |  ✓  |  ✓  |  ✓  | S390x Linux                         |
-| `sparc64-unknown-linux-gnu`       |  ✓  |     |     | SPARC Linux                         |
-| `sparcv9-sun-solaris`             |  ✓  |     |     | SPARC Solaris 10/11, illumos        |
-| `thumbv6m-none-eabi`              |  *  |     |     | Bare Cortex-M0, M0+, M1             |
-| `thumbv7em-none-eabi`             |  *  |     |     | Bare Cortex-M4, M7                  |
-| `thumbv7em-none-eabihf`           |  *  |     |     | Bare Cortex-M4F, M7F, FPU, hardfloat|
-| `thumbv7m-none-eabi`              |  *  |     |     | Bare Cortex-M3                      |
+|  Target                               | std |rustc|cargo| notes                               |
+|---------------------------------------|-----|-----|-----|-------------------------------------|
+| `aarch64-apple-ios`                   |  ✓  |     |     | ARM64 iOS                           |
+| `aarch64-fuchsia`                     |  ✓  |     |     | ARM64 Fuchsia                       |
+| `aarch64-linux-android`               |  ✓  |     |     | ARM64 Android                       |
+| `aarch64-unknown-linux-gnu`           |  ✓  |  ✓  |  ✓  | ARM64 Linux                         |
+| `aarch64-unknown-linux-musl`          |  ✓  |     |     | ARM64 Linux with MUSL               |
+| `aarch64-pc-windows-msvc`             |  ✓  |     |     | ARM64 Windows MSVC                  |
+| `arm-linux-androideabi`               |  ✓  |     |     | ARMv7 Android                       |
+| `arm-unknown-linux-gnueabi`           |  ✓  |  ✓  |  ✓  | ARMv6 Linux                         |
+| `arm-unknown-linux-gnueabihf`         |  ✓  |  ✓  |  ✓  | ARMv6 Linux, hardfloat              |
+| `arm-unknown-linux-musleabi`          |  ✓  |     |     | ARMv6 Linux with MUSL               |
+| `arm-unknown-linux-musleabihf`        |  ✓  |     |     | ARMv6 Linux, MUSL, hardfloat        |
+| `armebv7r-none-eabi`                  |  *  |     |     | Bare ARMv7-R, Big Endian            |
+| `armebv7r-none-eabihf`                |  *  |     |     | Bare ARMv7-R, Big Endian, hardfloat |
+| `armv5te-unknown-linux-gnueabi`       |  ✓  |     |     | ARMv5TE Linux                       |
+| `armv5te-unknown-linux-musleabi`      |  ✓  |     |     | ARMv5TE Linux with MUSL             |
+| `armv7-apple-ios`                     |  ✓  |     |     | ARMv7 iOS, Cortex-A8                |
+| `armv7-linux-androideabi`             |  ✓  |     |     | ARMv7a Android                      |
+| `armv7-unknown-linux-gnueabihf`       |  ✓  |  ✓  |  ✓  | ARMv7 Linux                         |
+| `armv7-unknown-linux-musleabihf`      |  ✓  |     |     | ARMv7 Linux with MUSL               |
+| `armv7r-none-eabi`                    |  ✓  |     |     | Bare ARMv7-R,                       |
+| `armv7r-none-eabihf`                  |  ✓  |     |     | Bare ARMv7-R, hardfloat             |
+| `armv7s-apple-ios`                    |  ✓  |     |     | ARMv7 iOS, Cortex-A9                |
+| `asmjs-unknown-emscripten`            |  ✓  |     |     | asm.js via Emscripten               |
+| `i386-apple-ios`                      |  ✓  |     |     | 32-bit x86 iOS                      |
+| `i586-pc-windows-msvc`                |  ✓  |     |     | 32-bit Windows w/o SSE              |
+| `i586-unknown-linux-gnu`              |  ✓  |     |     | 32-bit Linux w/o SSE                |
+| `i586-unknown-linux-musl`             |  ✓  |     |     | 32-bit Linux w/o SSE, MUSL          |
+| `i686-linux-android`                  |  ✓  |     |     | 32-bit x86 Android                  |
+| `i686-unknown-freebsd`                |  ✓  |  ✓  |  ✓  | 32-bit FreeBSD                      |
+| `i686-unknown-linux-musl`             |  ✓  |     |     | 32-bit Linux with MUSL              |
+| `mips-unknown-linux-gnu`              |  ✓  |  ✓  |  ✓  | MIPS Linux                          |
+| `mips-unknown-linux-musl`             |  ✓  |     |     | MIPS Linux with MUSL                |
+| `mips64-unknown-linux-gnuabi64`       |  ✓  |  ✓  |  ✓  | MIPS64 Linux, n64 ABI               |
+| `mips64el-unknown-linux-gnuabi64`     |  ✓  |  ✓  |  ✓  | MIPS64 (LE) Linux, n64 ABI          |
+| `mipsel-unknown-linux-gnu`            |  ✓  |  ✓  |  ✓  | MIPS (LE) Linux                     |
+| `mipsel-unknown-linux-musl`           |  ✓  |     |     | MIPS (LE) Linux with MUSL           |
+| `powerpc-unknown-linux-gnu`           |  ✓  |  ✓  |  ✓  | PowerPC Linux                       |
+| `powerpc64-unknown-linux-gnu`         |  ✓  |  ✓  |  ✓  | PPC64 Linux                         |
+| `powerpc64le-unknown-linux-gnu`       |  ✓  |  ✓  |  ✓  | PPC64LE Linux                       |
+| `riscv32imac-unknown-none-elf`        |  *  |     |     | Bare RISC-V (RV32IMAC ISA)          |
+| `riscv32imc-unknown-none-elf`         |  *  |     |     | Bare RISC-V (RV32IMC ISA)           |
+| `riscv64gc-unknown-none-elf`          |  *  |     |     | Bare RISC-V (RV64IMAFDC ISA)        |
+| `riscv64imac-unknown-none-elf`        |  *  |     |     | Bare RISC-V (RV64IMAC ISA)          |
+| `s390x-unknown-linux-gnu`             |  ✓  |  ✓  |  ✓  | S390x Linux                         |
+| `sparc64-unknown-linux-gnu`           |  ✓  |     |     | SPARC Linux                         |
+| `sparcv9-sun-solaris`                 |  ✓  |     |     | SPARC Solaris 10/11, illumos        |
+| `thumbv6m-none-eabi`                  |  *  |     |     | Bare Cortex-M0, M0+, M1             |
+| `thumbv7em-none-eabi`                 |  *  |     |     | Bare Cortex-M4, M7                  |
+| `thumbv7em-none-eabihf`               |  *  |     |     | Bare Cortex-M4F, M7F, FPU, hardfloat|
+| `thumbv7m-none-eabi`                  |  *  |     |     | Bare Cortex-M3                      |
 | `thumbv7neon-linux-androideabi`       |  ✓  |     |     | Thumb2-mode ARMv7a Android with NEON |
 | `thumbv7neon-unknown-linux-gnueabihf` |  ✓  |     |     | Thumb2-mode ARMv7a Linux with NEON   |
-| `wasm32-unknown-unknown`          |  ✓  |     |     | WebAssembly                         |
-| `wasm32-unknown-emscripten`       |  ✓  |     |     | WebAssembly via Emscripten          |
-| `x86_64-apple-ios`                |  ✓  |     |     | 64-bit x86 iOS                      |
-| `x86_64-fortanix-unknown-sgx`     |  ✓  |     |     | [Fortanix ABI] for 64-bit Intel SGX |
-| `x86_64-fuchsia`                  |  ✓  |     |     | 64-bit Fuchsia                      |
-| `x86_64-linux-android`            |  ✓  |     |     | 64-bit x86 Android                  |
-| `x86_64-rumprun-netbsd`           |  ✓  |     |     | 64-bit NetBSD Rump Kernel           |
-| `x86_64-sun-solaris`              |  ✓  |     |     | 64-bit Solaris 10/11, illumos       |
-| `x86_64-unknown-cloudabi`         |  ✓  |     |     | 64-bit CloudABI                     |
-| `x86_64-unknown-freebsd`          |  ✓  |  ✓  |  ✓  | 64-bit FreeBSD                      |
-| `x86_64-unknown-linux-gnux32`     |  ✓  |     |     | 64-bit Linux                        |
-| `x86_64-unknown-linux-musl`       |  ✓  |  ✓  |  ✓  | 64-bit Linux with MUSL              |
-| `x86_64-unknown-netbsd`           |  ✓  |  ✓  |  ✓  | NetBSD/amd64                        |
-| `x86_64-unknown-redox`            |  ✓  |     |     | Redox OS                            |
+| `wasm32-unknown-unknown`              |  ✓  |     |     | WebAssembly                         |
+| `wasm32-unknown-emscripten`           |  ✓  |     |     | WebAssembly via Emscripten          |
+| `x86_64-apple-ios`                    |  ✓  |     |     | 64-bit x86 iOS                      |
+| `x86_64-fortanix-unknown-sgx`         |  ✓  |     |     | [Fortanix ABI] for 64-bit Intel SGX |
+| `x86_64-fuchsia`                      |  ✓  |     |     | 64-bit Fuchsia                      |
+| `x86_64-linux-android`                |  ✓  |     |     | 64-bit x86 Android                  |
+| `x86_64-rumprun-netbsd`               |  ✓  |     |     | 64-bit NetBSD Rump Kernel           |
+| `x86_64-sun-solaris`                  |  ✓  |     |     | 64-bit Solaris 10/11, illumos       |
+| `x86_64-unknown-cloudabi`             |  ✓  |     |     | 64-bit CloudABI                     |
+| `x86_64-unknown-freebsd`              |  ✓  |  ✓  |  ✓  | 64-bit FreeBSD                      |
+| `x86_64-unknown-linux-gnux32`         |  ✓  |     |     | 64-bit Linux                        |
+| `x86_64-unknown-linux-musl`           |  ✓  |  ✓  |  ✓  | 64-bit Linux with MUSL              |
+| `x86_64-unknown-netbsd`               |  ✓  |  ✓  |  ✓  | NetBSD/amd64                        |
+| `x86_64-unknown-redox`                |  ✓  |     |     | Redox OS                            |
 
 [Fortanix ABI]: https://edp.fortanix.com
 

--- a/platform-support.md
+++ b/platform-support.md
@@ -100,6 +100,8 @@ these platforms are required to have each of the following:
 | `thumbv7em-none-eabi`             |  *  |     |     | Bare Cortex-M4, M7                  |
 | `thumbv7em-none-eabihf`           |  *  |     |     | Bare Cortex-M4F, M7F, FPU, hardfloat|
 | `thumbv7m-none-eabi`              |  *  |     |     | Bare Cortex-M3                      |
+| `thumbv7neon-linux-androideabi`       |  ✓  |     |     | Thumb2-mode ARMv7a Android with NEON |
+| `thumbv7neon-unknown-linux-gnueabihf` |  ✓  |     |     | Thumb2-mode ARMv7a Linux with NEON   |
 | `wasm32-unknown-unknown`          |  ✓  |     |     | WebAssembly                         |
 | `wasm32-unknown-emscripten`       |  ✓  |     |     | WebAssembly via Emscripten          |
 | `x86_64-apple-ios`                |  ✓  |     |     | 64-bit x86 iOS                      |

--- a/platform-support.md
+++ b/platform-support.md
@@ -55,17 +55,23 @@ these platforms are required to have each of the following:
 | `aarch64-linux-android`           |  ✓  |     |     | ARM64 Android                       |
 | `aarch64-unknown-linux-gnu`       |  ✓  |  ✓  |  ✓  | ARM64 Linux                         |
 | `aarch64-unknown-linux-musl`      |  ✓  |     |     | ARM64 Linux with MUSL               |
+| `aarch64-pc-windows-msvc`         |  ✓  |     |     | ARM64 Windows MSVC                  |
 | `arm-linux-androideabi`           |  ✓  |     |     | ARMv7 Android                       |
 | `arm-unknown-linux-gnueabi`       |  ✓  |  ✓  |  ✓  | ARMv6 Linux                         |
 | `arm-unknown-linux-gnueabihf`     |  ✓  |  ✓  |  ✓  | ARMv6 Linux, hardfloat              |
 | `arm-unknown-linux-musleabi`      |  ✓  |     |     | ARMv6 Linux with MUSL               |
 | `arm-unknown-linux-musleabihf`    |  ✓  |     |     | ARMv6 Linux, MUSL, hardfloat        |
+| `armebv7r-none-eabi`              |  *  |     |     | Bare ARMv7-R, Big Endian            |
+| `armebv7r-none-eabihf`            |  *  |     |     | Bare ARMv7-R, Big Endian, hardfloat |
 | `armv5te-unknown-linux-gnueabi`   |  ✓  |     |     | ARMv5TE Linux                       |
-| `armv7-apple-ios`                 |  ✓  |     |     | ARMv7 iOS, Cortex-a8                |
+| `armv5te-unknown-linux-musleabi`  |  ✓  |     |     | ARMv5TE Linux with MUSL             |
+| `armv7-apple-ios`                 |  ✓  |     |     | ARMv7 iOS, Cortex-A8                |
 | `armv7-linux-androideabi`         |  ✓  |     |     | ARMv7a Android                      |
 | `armv7-unknown-linux-gnueabihf`   |  ✓  |  ✓  |  ✓  | ARMv7 Linux                         |
 | `armv7-unknown-linux-musleabihf`  |  ✓  |     |     | ARMv7 Linux with MUSL               |
-| `armv7s-apple-ios`                |  ✓  |     |     | ARMv7 iOS, Cortex-a9                |
+| `armv7r-none-eabi`                |  ✓  |     |     | Bare ARMv7-R,                       |
+| `armv7r-none-eabihf`              |  ✓  |     |     | Bare ARMv7-R, hardfloat             |
+| `armv7s-apple-ios`                |  ✓  |     |     | ARMv7 iOS, Cortex-A9                |
 | `asmjs-unknown-emscripten`        |  ✓  |     |     | asm.js via Emscripten               |
 | `i386-apple-ios`                  |  ✓  |     |     | 32-bit x86 iOS                      |
 | `i586-pc-windows-msvc`            |  ✓  |     |     | 32-bit Windows w/o SSE              |
@@ -90,6 +96,10 @@ these platforms are required to have each of the following:
 | `s390x-unknown-linux-gnu`         |  ✓  |  ✓  |  ✓  | S390x Linux                         |
 | `sparc64-unknown-linux-gnu`       |  ✓  |     |     | SPARC Linux                         |
 | `sparcv9-sun-solaris`             |  ✓  |     |     | SPARC Solaris 10/11, illumos        |
+| `thumbv6m-none-eabi`              |  *  |     |     | Bare Cortex-M0, M0+, M1             |
+| `thumbv7em-none-eabi`             |  *  |     |     | Bare Cortex-M4, M7                  |
+| `thumbv7em-none-eabihf`           |  *  |     |     | Bare Cortex-M4F, M7F, FPU, hardfloat|
+| `thumbv7m-none-eabi`              |  *  |     |     | Bare Cortex-M3                      |
 | `wasm32-unknown-unknown`          |  ✓  |     |     | WebAssembly                         |
 | `wasm32-unknown-emscripten`       |  ✓  |     |     | WebAssembly via Emscripten          |
 | `x86_64-apple-ios`                |  ✓  |     |     | 64-bit x86 iOS                      |
@@ -101,7 +111,7 @@ these platforms are required to have each of the following:
 | `x86_64-unknown-cloudabi`         |  ✓  |     |     | 64-bit CloudABI                     |
 | `x86_64-unknown-freebsd`          |  ✓  |  ✓  |  ✓  | 64-bit FreeBSD                      |
 | `x86_64-unknown-linux-gnux32`     |  ✓  |     |     | 64-bit Linux                        |
-| `x86_64-unknown-linux-musl`       |  ✓  |  ✓   | ✓    | 64-bit Linux with MUSL              |
+| `x86_64-unknown-linux-musl`       |  ✓  |  ✓  |  ✓  | 64-bit Linux with MUSL              |
 | `x86_64-unknown-netbsd`           |  ✓  |  ✓  |  ✓  | NetBSD/amd64                        |
 | `x86_64-unknown-redox`            |  ✓  |     |     | Redox OS                            |
 
@@ -148,10 +158,6 @@ Official builds are not available.
 | `mipsel-unknown-linux-uclibc`   |  ✓  |     |     | MIPS (LE) Linux with uClibc                              |
 | `msp430-none-elf`               |  *  |     |     | 16-bit MSP430 microcontrollers                           |
 | `sparc64-unknown-netbsd`        |  ✓  |  ✓  |     | NetBSD/sparc64                                           |
-| `thumbv6m-none-eabi`            |  *  |     |     | Bare Cortex-M0, M0+, M1                                  |
-| `thumbv7em-none-eabi`           |  *  |     |     | Bare Cortex-M4, M7                                       |
-| `thumbv7em-none-eabihf`         |  *  |     |     | Bare Cortex-M4F, M7F, FPU, hardfloat                     |
-| `thumbv7m-none-eabi`            |  *  |     |     | Bare Cortex-M3                                           |
 | `x86_64-pc-windows-msvc` (XP)   |  ✓  |     |     | Windows XP support                                       |
 | `x86_64-unknown-bitrig`         |  ✓  |  ✓  |     | 64-bit Bitrig                                            |
 | `x86_64-unknown-dragonfly`      |  ✓  |  ✓  |     | 64-bit DragonFlyBSD                                      |


### PR DESCRIPTION
This upgrades all `thumb` targets from Tier 3 to Tier 2 (although they're technically closer to Tier 1, since PRs are gated on a few tests passing in Qemu), and also adds previously unlisted targets in the right Tier.

Closes #198
Closes https://github.com/rust-lang/rust-forge/issues/177
Closes https://github.com/rust-lang/rust-forge/issues/186