### PR TITLE
Add Rust Pontoon link for translators

### DIFF
--- a/index.md
+++ b/index.md
@@ -53,6 +53,7 @@ PRs against [rust-lang/rust-forge].
 * [Bibliography](bibliography.html). Research papers and other links to projects that influenced Rust. Papers about Rust.
 * [Cross compilation resources](cross-compilation/index.html)
 * [Other Rust Installation Methods](other-installation-methods.html)
+* [Rust Pontoon](https://pontoon.rust-lang.org/). Translating the Rust website.
 
 
 <script src="js/moment.min.js"></script>


### PR DESCRIPTION
It seems apropriate to add a link to Pontoon here.
Based on discussion in https://internals.rust-lang.org/t/translating-the-stdlib-docs/10384