### PR TITLE
Fix broken reference links

### DIFF
--- a/other-installation-methods.md
+++ b/other-installation-methods.md
@@ -169,10 +169,8 @@ Past releases can be found in [the archives].
 
 [installation page]: https://www.rust-lang.org/tools/install
 [`rustup`]: https://github.com/rust-lang/rustup.rs
-[other-rustup]:
-  https://github.com/rust-lang/rustup.rs#other-installation-methods
-[`rustup-init.exe`]:
-  https://static.rust-lang.org/rustup/dist/i686-pc-windows-gnu/rustup-init.exe
+[other-rustup]: https://github.com/rust-lang/rustup.rs#other-installation-methods
+[`rustup-init.exe`]: https://static.rust-lang.org/rustup/dist/i686-pc-windows-gnu/rustup-init.exe
 [`rustup-init.sh`]: https://static.rust-lang.org/rustup/rustup-init.sh
 [homebrew]: http://brew.sh/
 [chocolatey]: http://chocolatey.org/

--- a/releases.md
+++ b/releases.md
@@ -44,62 +44,35 @@ TODO: Update me
 - [Mac OS X x86_64 pkg][1.7.0-osx-x64-pkg] ([signature][1.7.0-osx-x64-pkg-sig])
 
 [1.7.0-announce]: http://blog.rust-lang.org/2016/03/02/Rust-1.7.html
-[1.7.0-notes]:
-  https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-170-2016-03-03
+[1.7.0-notes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-170-2016-03-03
 [1.7.0-tar]: https://static.rust-lang.org/dist/rustc-1.7.0-src.tar.gz
 [1.7.0-tar-sig]: https://static.rust-lang.org/dist/rustc-1.7.0-src.tar.gz.asc
-[1.7.0-windows-x64]:
-  https://static.rust-lang.org/dist/rust-1.7.0-x86_64-pc-windows-gnu.exe
-[1.7.0-windows-x64-sig]:
-  https://static.rust-lang.org/dist/rust-1.7.0-x86_64-pc-windows-gnu.exe.asc
-[1.7.0-windows-msi-x64]:
-  https://static.rust-lang.org/dist/rust-1.7.0-x86_64-pc-windows-gnu.msi
-[1.7.0-windows-msi-x64-sig]:
-  https://static.rust-lang.org/dist/rust-1.7.0-x86_64-pc-windows-gnu.msi.asc
-[1.7.0-windows-msvc-exe-x64]:
-  https://static.rust-lang.org/dist/rust-1.7.0-x86_64-pc-windows-msvc.exe
-[1.7.0-windows-msvc-exe-x64-sig]:
-  https://static.rust-lang.org/dist/rust-1.7.0-x86_64-pc-windows-msvc.exe.asc
-[1.7.0-windows-msvc-msi-x64]:
-  https://static.rust-lang.org/dist/rust-1.7.0-x86_64-pc-windows-msvc.msi
-[1.7.0-windows-msvc-msi-x64-sig]:
-  https://static.rust-lang.org/dist/rust-1.7.0-x86_64-pc-windows-msvc.msi.asc
-[1.7.0-windows-x32]:
-  https://static.rust-lang.org/dist/rust-1.7.0-i686-pc-windows-gnu.exe
-[1.7.0-windows-x32-sig]:
-  https://static.rust-lang.org/dist/rust-1.7.0-i686-pc-windows-gnu.exe.asc
-[1.7.0-windows-msi-x32]:
-  https://static.rust-lang.org/dist/rust-1.7.0-i686-pc-windows-gnu.msi
-[1.7.0-windows-msi-x32-sig]:
-  https://static.rust-lang.org/dist/rust-1.7.0-i686-pc-windows-gnu.msi.asc
-[1.7.0-windows-msvc-exe-x32]:
-  https://static.rust-lang.org/dist/rust-1.7.0-i686-pc-windows-msvc.exe
-[1.7.0-windows-msvc-exe-x32-sig]:
-  https://static.rust-lang.org/dist/rust-1.7.0-i686-pc-windows-msvc.exe.asc
-[1.7.0-windows-msvc-msi-x32]:
-  https://static.rust-lang.org/dist/rust-1.7.0-i686-pc-windows-msvc.msi
-[1.7.0-windows-msvc-msi-x32-sig]:
-  https://static.rust-lang.org/dist/rust-1.7.0-i686-pc-windows-msvc.msi.asc
-[1.7.0-linux-x32]:
-  https://static.rust-lang.org/dist/rust-1.7.0-i686-unknown-linux-gnu.tar.gz
-[1.7.0-linux-x32-sig]:
-  https://static.rust-lang.org/dist/rust-1.7.0-i686-unknown-linux-gnu.tar.gz.asc
-[1.7.0-linux-x64]:
-  https://static.rust-lang.org/dist/rust-1.7.0-x86_64-unknown-linux-gnu.tar.gz
-[1.7.0-linux-x64-sig]:
-  https://static.rust-lang.org/dist/rust-1.7.0-x86_64-unknown-linux-gnu.tar.gz.asc
-[1.7.0-osx-x32-pkg]:
-  https://static.rust-lang.org/dist/rust-1.7.0-i686-apple-darwin.pkg
-[1.7.0-osx-x32-pkg-sig]:
-  https://static.rust-lang.org/dist/rust-1.7.0-i686-apple-darwin.pkg.asc
-[1.7.0-osx-x32-tar]:
-  https://static.rust-lang.org/dist/rust-1.7.0-i686-apple-darwin.tar.gz
-[1.7.0-osx-x32-tar-sig]:
-  https://static.rust-lang.org/dist/rust-1.7.0-i686-apple-darwin.tar.gz.asc
-[1.7.0-osx-x64-pkg]:
-  https://static.rust-lang.org/dist/rust-1.7.0-x86_64-apple-darwin.pkg
-[1.7.0-osx-x64-pkg-sig]:
-  https://static.rust-lang.org/dist/rust-1.7.0-x86_64-apple-darwin.pkg.asc
+[1.7.0-windows-x64]: https://static.rust-lang.org/dist/rust-1.7.0-x86_64-pc-windows-gnu.exe
+[1.7.0-windows-x64-sig]: https://static.rust-lang.org/dist/rust-1.7.0-x86_64-pc-windows-gnu.exe.asc
+[1.7.0-windows-msi-x64]: https://static.rust-lang.org/dist/rust-1.7.0-x86_64-pc-windows-gnu.msi
+[1.7.0-windows-msi-x64-sig]: https://static.rust-lang.org/dist/rust-1.7.0-x86_64-pc-windows-gnu.msi.asc
+[1.7.0-windows-msvc-exe-x64]: https://static.rust-lang.org/dist/rust-1.7.0-x86_64-pc-windows-msvc.exe
+[1.7.0-windows-msvc-exe-x64-sig]: https://static.rust-lang.org/dist/rust-1.7.0-x86_64-pc-windows-msvc.exe.asc
+[1.7.0-windows-msvc-msi-x64]: https://static.rust-lang.org/dist/rust-1.7.0-x86_64-pc-windows-msvc.msi
+[1.7.0-windows-msvc-msi-x64-sig]: https://static.rust-lang.org/dist/rust-1.7.0-x86_64-pc-windows-msvc.msi.asc
+[1.7.0-windows-x32]: https://static.rust-lang.org/dist/rust-1.7.0-i686-pc-windows-gnu.exe
+[1.7.0-windows-x32-sig]: https://static.rust-lang.org/dist/rust-1.7.0-i686-pc-windows-gnu.exe.asc
+[1.7.0-windows-msi-x32]: https://static.rust-lang.org/dist/rust-1.7.0-i686-pc-windows-gnu.msi
+[1.7.0-windows-msi-x32-sig]: https://static.rust-lang.org/dist/rust-1.7.0-i686-pc-windows-gnu.msi.asc
+[1.7.0-windows-msvc-exe-x32]: https://static.rust-lang.org/dist/rust-1.7.0-i686-pc-windows-msvc.exe
+[1.7.0-windows-msvc-exe-x32-sig]: https://static.rust-lang.org/dist/rust-1.7.0-i686-pc-windows-msvc.exe.asc
+[1.7.0-windows-msvc-msi-x32]: https://static.rust-lang.org/dist/rust-1.7.0-i686-pc-windows-msvc.msi
+[1.7.0-windows-msvc-msi-x32-sig]: https://static.rust-lang.org/dist/rust-1.7.0-i686-pc-windows-msvc.msi.asc
+[1.7.0-linux-x32]: https://static.rust-lang.org/dist/rust-1.7.0-i686-unknown-linux-gnu.tar.gz
+[1.7.0-linux-x32-sig]: https://static.rust-lang.org/dist/rust-1.7.0-i686-unknown-linux-gnu.tar.gz.asc
+[1.7.0-linux-x64]: https://static.rust-lang.org/dist/rust-1.7.0-x86_64-unknown-linux-gnu.tar.gz
+[1.7.0-linux-x64-sig]: https://static.rust-lang.org/dist/rust-1.7.0-x86_64-unknown-linux-gnu.tar.gz.asc
+[1.7.0-osx-x32-pkg]: https://static.rust-lang.org/dist/rust-1.7.0-i686-apple-darwin.pkg
+[1.7.0-osx-x32-pkg-sig]: https://static.rust-lang.org/dist/rust-1.7.0-i686-apple-darwin.pkg.asc
+[1.7.0-osx-x32-tar]: https://static.rust-lang.org/dist/rust-1.7.0-i686-apple-darwin.tar.gz
+[1.7.0-osx-x32-tar-sig]: https://static.rust-lang.org/dist/rust-1.7.0-i686-apple-darwin.tar.gz.asc
+[1.7.0-osx-x64-pkg]: https://static.rust-lang.org/dist/rust-1.7.0-x86_64-apple-darwin.pkg
+[1.7.0-osx-x64-pkg-sig]: https://static.rust-lang.org/dist/rust-1.7.0-x86_64-apple-darwin.pkg.asc
 
 ## 1.6.0
 
@@ -107,8 +80,7 @@ TODO: Update me
 - [Release notes][1.6.0-notes]
 
 [1.6.0-announce]: http://blog.rust-lang.org/2016/01/21/Rust-1.6.html
-[1.6.0-notes]:
-  https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-160-2016-01-21
+[1.6.0-notes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-160-2016-01-21
 
 ## 1.5.0
 
@@ -116,8 +88,7 @@ TODO: Update me
 - [Release notes][1.5.0-notes]
 
 [1.5.0-announce]: http://blog.rust-lang.org/2015/12/10/Rust-1.5.html
-[1.5.0-notes]:
-  https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-150-2015-12-10
+[1.5.0-notes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-150-2015-12-10
 
 ## 1.4.0
 
@@ -125,8 +96,7 @@ TODO: Update me
 - [Release notes][1.4.0-notes]
 
 [1.4.0-announce]: http://blog.rust-lang.org/2015/10/29/Rust-1.4.html
-[1.4.0-notes]:
-  https://github.com/rust-lang/rust/blob/8ab8581f6921bc7a8e3fa4defffd2814372dcb15/RELEASES.md#version-140-october-2015
+[1.4.0-notes]: https://github.com/rust-lang/rust/blob/8ab8581f6921bc7a8e3fa4defffd2814372dcb15/RELEASES.md#version-140-october-2015
 
 ## 1.3.0
 
@@ -134,8 +104,7 @@ TODO: Update me
 - [Release notes][1.3.0-notes]
 
 [1.3.0-announce]: http://blog.rust-lang.org/2015/09/17/Rust-1.3.html
-[1.3.0-notes]:
-  https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-130-september-2015
+[1.3.0-notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-130-september-2015
 
 ## 1.2.0
 
@@ -143,8 +112,7 @@ TODO: Update me
 - [Release notes][1.2.0-notes]
 
 [1.2.0-announce]: http://blog.rust-lang.org/2015/08/06/Rust-1.2.html
-[1.2.0-notes]:
-  https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-120-2015-08-07
+[1.2.0-notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-120-2015-08-07
 
 ## 1.1.0
 
@@ -152,8 +120,7 @@ TODO: Update me
 - [Release notes][1.1.0-notes]
 
 [1.1.0-announce]: http://blog.rust-lang.org/2015/06/25/Rust-1.1.html
-[1.1.0-notes]:
-  https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-110-2015-06-25
+[1.1.0-notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-110-2015-06-25
 
 ## 1.0.0
 
@@ -161,8 +128,7 @@ TODO: Update me
 - [Release notes][1.0.0-notes]
 
 [1.0.0-announce]: http://blog.rust-lang.org/2015/05/15/Rust-1.0.html
-[1.0.0-notes]:
-  https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-100-2015-05-15
+[1.0.0-notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-100-2015-05-15
 
 ## 1.0.0-beta
 
@@ -197,53 +163,30 @@ TODO: Update me
   ([signature][1.0.0-alpha.2-osx-x32-tar-sig])
 - [Documentation][1.0.0-alpha.2-docs]
 
-[1.0.0-alpha.2-announce]:
-  http://blog.rust-lang.org/2015/02/20/Rust-1.0-alpha2.html
-[1.0.0-alpha.2-notes]:
-  https://github.com/mozilla/rust/blob/1.0.0-alpha.2/RELEASES.md
+[1.0.0-alpha.2-announce]: http://blog.rust-lang.org/2015/02/20/Rust-1.0-alpha2.html
+[1.0.0-alpha.2-notes]: https://github.com/mozilla/rust/blob/1.0.0-alpha.2/RELEASES.md
 [1.0.0-alpha.2-tar]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2.tar.gz
-[1.0.0-alpha.2-tar-sig]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.2.tar.gz.asc
-[1.0.0-alpha.2-windows-x64]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-x86_64-pc-windows-gnu.exe
-[1.0.0-alpha.2-windows-x64-sig]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-x86_64-pc-windows-gnu.exe.asc
-[1.0.0-alpha.2-windows-x32]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-i686-pc-windows-gnu.exe
-[1.0.0-alpha.2-windows-x32-sig]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-i686-pc-windows-gnu.exe.asc
-[1.0.0-alpha.2-windows-msi-x64]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-x86_64-pc-windows-gnu.msi
-[1.0.0-alpha.2-windows-msi-x64-sig]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-x86_64-pc-windows-gnu.msi.asc
-[1.0.0-alpha.2-windows-msi-x32]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-i686-pc-windows-gnu.msi
-[1.0.0-alpha.2-windows-msi-x32-sig]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-i686-pc-windows-gnu.msi.asc
-[1.0.0-alpha.2-linux-x64]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-x86_64-unknown-linux-gnu.tar.gz
-[1.0.0-alpha.2-linux-x64-sig]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-x86_64-unknown-linux-gnu.tar.gz.asc
-[1.0.0-alpha.2-linux-x32]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-i686-unknown-linux-gnu.tar.gz
-[1.0.0-alpha.2-linux-x32-sig]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-i686-unknown-linux-gnu.tar.gz.asc
-[1.0.0-alpha.2-osx-x64-pkg]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-x86_64-apple-darwin.pkg
-[1.0.0-alpha.2-osx-x64-pkg-sig]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-x86_64-apple-darwin.pkg.asc
-[1.0.0-alpha.2-osx-x32-pkg]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-i686-apple-darwin.pkg
-[1.0.0-alpha.2-osx-x32-pkg-sig]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-i686-apple-darwin.pkg.asc
-[1.0.0-alpha.2-osx-x64-tar]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-x86_64-apple-darwin.tar.gz
-[1.0.0-alpha.2-osx-x64-tar-sig]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-x86_64-apple-darwin.tar.gz.asc
-[1.0.0-alpha.2-osx-x32-tar]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-i686-apple-darwin.tar.gz
-[1.0.0-alpha.2-osx-x32-tar-sig]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-i686-apple-darwin.tar.gz.asc
+[1.0.0-alpha.2-tar-sig]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2.tar.gz.asc
+[1.0.0-alpha.2-windows-x64]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-x86_64-pc-windows-gnu.exe
+[1.0.0-alpha.2-windows-x64-sig]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-x86_64-pc-windows-gnu.exe.asc
+[1.0.0-alpha.2-windows-x32]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-i686-pc-windows-gnu.exe
+[1.0.0-alpha.2-windows-x32-sig]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-i686-pc-windows-gnu.exe.asc
+[1.0.0-alpha.2-windows-msi-x64]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-x86_64-pc-windows-gnu.msi
+[1.0.0-alpha.2-windows-msi-x64-sig]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-x86_64-pc-windows-gnu.msi.asc
+[1.0.0-alpha.2-windows-msi-x32]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-i686-pc-windows-gnu.msi
+[1.0.0-alpha.2-windows-msi-x32-sig]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-i686-pc-windows-gnu.msi.asc
+[1.0.0-alpha.2-linux-x64]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-x86_64-unknown-linux-gnu.tar.gz
+[1.0.0-alpha.2-linux-x64-sig]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-x86_64-unknown-linux-gnu.tar.gz.asc
+[1.0.0-alpha.2-linux-x32]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-i686-unknown-linux-gnu.tar.gz
+[1.0.0-alpha.2-linux-x32-sig]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-i686-unknown-linux-gnu.tar.gz.asc
+[1.0.0-alpha.2-osx-x64-pkg]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-x86_64-apple-darwin.pkg
+[1.0.0-alpha.2-osx-x64-pkg-sig]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-x86_64-apple-darwin.pkg.asc
+[1.0.0-alpha.2-osx-x32-pkg]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-i686-apple-darwin.pkg
+[1.0.0-alpha.2-osx-x32-pkg-sig]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-i686-apple-darwin.pkg.asc
+[1.0.0-alpha.2-osx-x64-tar]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-x86_64-apple-darwin.tar.gz
+[1.0.0-alpha.2-osx-x64-tar-sig]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-x86_64-apple-darwin.tar.gz.asc
+[1.0.0-alpha.2-osx-x32-tar]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-i686-apple-darwin.tar.gz
+[1.0.0-alpha.2-osx-x32-tar-sig]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.2-i686-apple-darwin.tar.gz.asc
 [1.0.0-alpha.2-docs]: http://doc.rust-lang.org/1.0.0-alpha.2/index.html
 
 ## 1.0.0-alpha
@@ -270,43 +213,25 @@ TODO: Update me
 - [Documentation][1.0.0-alpha-docs]
 
 [1.0.0-alpha-announce]: http://blog.rust-lang.org/2015/01/09/Rust-1.0-alpha.html
-[1.0.0-alpha-notes]:
-  https://github.com/mozilla/rust/blob/1.0.0-alpha/RELEASES.md
+[1.0.0-alpha-notes]: https://github.com/mozilla/rust/blob/1.0.0-alpha/RELEASES.md
 [1.0.0-alpha-tar]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.tar.gz
-[1.0.0-alpha-tar-sig]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha.tar.gz.asc
-[1.0.0-alpha-windows-x64]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha-x86_64-pc-windows-gnu.exe
-[1.0.0-alpha-windows-x64-sig]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha-x86_64-pc-windows-gnu.exe.asc
-[1.0.0-alpha-windows-x32]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha-i686-pc-windows-gnu.exe
-[1.0.0-alpha-windows-x32-sig]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha-i686-pc-windows-gnu.exe.asc
-[1.0.0-alpha-linux-x64]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha-x86_64-unknown-linux-gnu.tar.gz
-[1.0.0-alpha-linux-x64-sig]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha-x86_64-unknown-linux-gnu.tar.gz.asc
-[1.0.0-alpha-linux-x32]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha-i686-unknown-linux-gnu.tar.gz
-[1.0.0-alpha-linux-x32-sig]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha-i686-unknown-linux-gnu.tar.gz.asc
-[1.0.0-alpha-osx-x64-pkg]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha-x86_64-apple-darwin.pkg
-[1.0.0-alpha-osx-x64-pkg-sig]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha-x86_64-apple-darwin.pkg.asc
-[1.0.0-alpha-osx-x32-pkg]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha-i686-apple-darwin.pkg
-[1.0.0-alpha-osx-x32-pkg-sig]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha-i686-apple-darwin.pkg.asc
-[1.0.0-alpha-osx-x64-tar]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha-x86_64-apple-darwin.tar.gz
-[1.0.0-alpha-osx-x64-tar-sig]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha-x86_64-apple-darwin.tar.gz.asc
-[1.0.0-alpha-osx-x32-tar]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha-i686-apple-darwin.tar.gz
-[1.0.0-alpha-osx-x32-tar-sig]:
-  https://static.rust-lang.org/dist/rust-1.0.0-alpha-i686-apple-darwin.tar.gz.asc
+[1.0.0-alpha-tar-sig]: https://static.rust-lang.org/dist/rust-1.0.0-alpha.tar.gz.asc
+[1.0.0-alpha-windows-x64]: https://static.rust-lang.org/dist/rust-1.0.0-alpha-x86_64-pc-windows-gnu.exe
+[1.0.0-alpha-windows-x64-sig]: https://static.rust-lang.org/dist/rust-1.0.0-alpha-x86_64-pc-windows-gnu.exe.asc
+[1.0.0-alpha-windows-x32]: https://static.rust-lang.org/dist/rust-1.0.0-alpha-i686-pc-windows-gnu.exe
+[1.0.0-alpha-windows-x32-sig]: https://static.rust-lang.org/dist/rust-1.0.0-alpha-i686-pc-windows-gnu.exe.asc
+[1.0.0-alpha-linux-x64]: https://static.rust-lang.org/dist/rust-1.0.0-alpha-x86_64-unknown-linux-gnu.tar.gz
+[1.0.0-alpha-linux-x64-sig]: https://static.rust-lang.org/dist/rust-1.0.0-alpha-x86_64-unknown-linux-gnu.tar.gz.asc
+[1.0.0-alpha-linux-x32]: https://static.rust-lang.org/dist/rust-1.0.0-alpha-i686-unknown-linux-gnu.tar.gz
+[1.0.0-alpha-linux-x32-sig]: https://static.rust-lang.org/dist/rust-1.0.0-alpha-i686-unknown-linux-gnu.tar.gz.asc
+[1.0.0-alpha-osx-x64-pkg]: https://static.rust-lang.org/dist/rust-1.0.0-alpha-x86_64-apple-darwin.pkg
+[1.0.0-alpha-osx-x64-pkg-sig]: https://static.rust-lang.org/dist/rust-1.0.0-alpha-x86_64-apple-darwin.pkg.asc
+[1.0.0-alpha-osx-x32-pkg]: https://static.rust-lang.org/dist/rust-1.0.0-alpha-i686-apple-darwin.pkg
+[1.0.0-alpha-osx-x32-pkg-sig]: https://static.rust-lang.org/dist/rust-1.0.0-alpha-i686-apple-darwin.pkg.asc
+[1.0.0-alpha-osx-x64-tar]: https://static.rust-lang.org/dist/rust-1.0.0-alpha-x86_64-apple-darwin.tar.gz
+[1.0.0-alpha-osx-x64-tar-sig]: https://static.rust-lang.org/dist/rust-1.0.0-alpha-x86_64-apple-darwin.tar.gz.asc
+[1.0.0-alpha-osx-x32-tar]: https://static.rust-lang.org/dist/rust-1.0.0-alpha-i686-apple-darwin.tar.gz
+[1.0.0-alpha-osx-x32-tar-sig]: https://static.rust-lang.org/dist/rust-1.0.0-alpha-i686-apple-darwin.tar.gz.asc
 [1.0.0-alpha-docs]: http://doc.rust-lang.org/1.0.0-alpha/index.html
 
 # Rust 0.x
@@ -334,43 +259,26 @@ longer explanation in the [[detailed release notes|Doc detailed release notes]].
   ([signature][0.12.0-osx-x32-tar-sig])
 - [Documentation][0.12.0-docs]
 
-[0.12.0-announce]:
-  https://mail.mozilla.org/pipermail/rust-dev/2014-October/011267.html
+[0.12.0-announce]: https://mail.mozilla.org/pipermail/rust-dev/2014-October/011267.html
 [0.12.0-notes]: https://github.com/mozilla/rust/blob/0.12.0/RELEASES.md
 [0.12.0-tar]: https://static.rust-lang.org/dist/rust-0.12.0.tar.gz
 [0.12.0-tar-sig]: https://static.rust-lang.org/dist/rust-0.12.0.tar.gz.asc
-[0.12.0-windows-x64]:
-  https://static.rust-lang.org/dist/rust-0.12.0-x86_64-w64-mingw32.exe
-[0.12.0-windows-x64-sig]:
-  https://static.rust-lang.org/dist/rust-0.12.0-x86_64-w64-mingw32.exe.asc
-[0.12.0-windows-x32]:
-  https://static.rust-lang.org/dist/rust-0.12.0-i686-w64-mingw32.exe
-[0.12.0-windows-x32-sig]:
-  https://static.rust-lang.org/dist/rust-0.12.0-i686-w64-mingw32.exe.asc
-[0.12.0-linux-x64]:
-  https://static.rust-lang.org/dist/rust-0.12.0-x86_64-unknown-linux-gnu.tar.gz
-[0.12.0-linux-x64-sig]:
-  https://static.rust-lang.org/dist/rust-0.12.0-x86_64-unknown-linux-gnu.tar.gz.asc
-[0.12.0-linux-x32]:
-  https://static.rust-lang.org/dist/rust-0.12.0-i686-unknown-linux-gnu.tar.gz
-[0.12.0-linux-x32-sig]:
-  https://static.rust-lang.org/dist/rust-0.12.0-i686-unknown-linux-gnu.tar.gz.asc
-[0.12.0-osx-x64-pkg]:
-  https://static.rust-lang.org/dist/rust-0.12.0-x86_64-apple-darwin.pkg
-[0.12.0-osx-x64-pkg-sig]:
-  https://static.rust-lang.org/dist/rust-0.12.0-x86_64-apple-darwin.pkg.asc
-[0.12.0-osx-x32-pkg]:
-  https://static.rust-lang.org/dist/rust-0.12.0-i686-apple-darwin.pkg
-[0.12.0-osx-x32-pkg-sig]:
-  https://static.rust-lang.org/dist/rust-0.12.0-i686-apple-darwin.pkg.asc
-[0.12.0-osx-x64-tar]:
-  https://static.rust-lang.org/dist/rust-0.12.0-x86_64-apple-darwin.tar.gz
-[0.12.0-osx-x64-tar-sig]:
-  https://static.rust-lang.org/dist/rust-0.12.0-x86_64-apple-darwin.tar.gz.asc
-[0.12.0-osx-x32-tar]:
-  https://static.rust-lang.org/dist/rust-0.12.0-i686-apple-darwin.tar.gz
-[0.12.0-osx-x32-tar-sig]:
-  https://static.rust-lang.org/dist/rust-0.12.0-i686-apple-darwin.tar.gz.asc
+[0.12.0-windows-x64]: https://static.rust-lang.org/dist/rust-0.12.0-x86_64-w64-mingw32.exe
+[0.12.0-windows-x64-sig]: https://static.rust-lang.org/dist/rust-0.12.0-x86_64-w64-mingw32.exe.asc
+[0.12.0-windows-x32]: https://static.rust-lang.org/dist/rust-0.12.0-i686-w64-mingw32.exe
+[0.12.0-windows-x32-sig]: https://static.rust-lang.org/dist/rust-0.12.0-i686-w64-mingw32.exe.asc
+[0.12.0-linux-x64]: https://static.rust-lang.org/dist/rust-0.12.0-x86_64-unknown-linux-gnu.tar.gz
+[0.12.0-linux-x64-sig]: https://static.rust-lang.org/dist/rust-0.12.0-x86_64-unknown-linux-gnu.tar.gz.asc
+[0.12.0-linux-x32]: https://static.rust-lang.org/dist/rust-0.12.0-i686-unknown-linux-gnu.tar.gz
+[0.12.0-linux-x32-sig]: https://static.rust-lang.org/dist/rust-0.12.0-i686-unknown-linux-gnu.tar.gz.asc
+[0.12.0-osx-x64-pkg]: https://static.rust-lang.org/dist/rust-0.12.0-x86_64-apple-darwin.pkg
+[0.12.0-osx-x64-pkg-sig]: https://static.rust-lang.org/dist/rust-0.12.0-x86_64-apple-darwin.pkg.asc
+[0.12.0-osx-x32-pkg]: https://static.rust-lang.org/dist/rust-0.12.0-i686-apple-darwin.pkg
+[0.12.0-osx-x32-pkg-sig]: https://static.rust-lang.org/dist/rust-0.12.0-i686-apple-darwin.pkg.asc
+[0.12.0-osx-x64-tar]: https://static.rust-lang.org/dist/rust-0.12.0-x86_64-apple-darwin.tar.gz
+[0.12.0-osx-x64-tar-sig]: https://static.rust-lang.org/dist/rust-0.12.0-x86_64-apple-darwin.tar.gz.asc
+[0.12.0-osx-x32-tar]: https://static.rust-lang.org/dist/rust-0.12.0-i686-apple-darwin.tar.gz
+[0.12.0-osx-x32-tar-sig]: https://static.rust-lang.org/dist/rust-0.12.0-i686-apple-darwin.tar.gz.asc
 [0.12.0-docs]: http://doc.rust-lang.org/0.12.0/index.html
 
 ## 0.11.0
@@ -390,37 +298,24 @@ longer explanation in the [[detailed release notes|Doc detailed release notes]].
   ([signature][0.11.0-osx-x32-tar-sig])
 - [Documentation][0.11.0-docs]
 
-[0.11.0-announce]:
-  https://mail.mozilla.org/pipermail/rust-dev/2014-July/010655.html
+[0.11.0-announce]: https://mail.mozilla.org/pipermail/rust-dev/2014-July/010655.html
 [0.11.0-notes]: https://github.com/mozilla/rust/blob/0.11.0/RELEASES.txt
 [0.11.0-tar]: https://static.rust-lang.org/dist/rust-0.11.0.tar.gz
 [0.11.0-tar-sig]: https://static.rust-lang.org/dist/rust-0.11.0.tar.gz.asc
 [0.11.0-exe]: https://static.rust-lang.org/dist/rust-0.11.0-install.exe
 [0.11.0-exe-sig]: https://static.rust-lang.org/dist/rust-0.11.0-install.exe.asc
-[0.11.0-linux-x64]:
-  https://static.rust-lang.org/dist/rust-0.11.0-x86_64-unknown-linux-gnu.tar.gz
-[0.11.0-linux-x64-sig]:
-  https://static.rust-lang.org/dist/rust-0.11.0-x86_64-unknown-linux-gnu.tar.gz.asc
-[0.11.0-linux-x32]:
-  https://static.rust-lang.org/dist/rust-0.11.0-i686-unknown-linux-gnu.tar.gz
-[0.11.0-linux-x32-sig]:
-  https://static.rust-lang.org/dist/rust-0.11.0-i686-unknown-linux-gnu.tar.gz.asc
-[0.11.0-osx-x64-pkg]:
-  https://static.rust-lang.org/dist/rust-0.11.0-x86_64-apple-darwin.pkg
-[0.11.0-osx-x64-pkg-sig]:
-  https://static.rust-lang.org/dist/rust-0.11.0-x86_64-apple-darwin.pkg.asc
-[0.11.0-osx-x32-pkg]:
-  https://static.rust-lang.org/dist/rust-0.11.0-i686-apple-darwin.pkg
-[0.11.0-osx-x32-pkg-sig]:
-  https://static.rust-lang.org/dist/rust-0.11.0-i686-apple-darwin.pkg.asc
-[0.11.0-osx-x64-tar]:
-  https://static.rust-lang.org/dist/rust-0.11.0-x86_64-apple-darwin.tar.gz
-[0.11.0-osx-x64-tar-sig]:
-  https://static.rust-lang.org/dist/rust-0.11.0-x86_64-apple-darwin.tar.gz.asc
-[0.11.0-osx-x32-tar]:
-  https://static.rust-lang.org/dist/rust-0.11.0-i686-apple-darwin.tar.gz
-[0.11.0-osx-x32-tar-sig]:
-  https://static.rust-lang.org/dist/rust-0.11.0-i686-apple-darwin.tar.gz.asc
+[0.11.0-linux-x64]: https://static.rust-lang.org/dist/rust-0.11.0-x86_64-unknown-linux-gnu.tar.gz
+[0.11.0-linux-x64-sig]: https://static.rust-lang.org/dist/rust-0.11.0-x86_64-unknown-linux-gnu.tar.gz.asc
+[0.11.0-linux-x32]: https://static.rust-lang.org/dist/rust-0.11.0-i686-unknown-linux-gnu.tar.gz
+[0.11.0-linux-x32-sig]: https://static.rust-lang.org/dist/rust-0.11.0-i686-unknown-linux-gnu.tar.gz.asc
+[0.11.0-osx-x64-pkg]: https://static.rust-lang.org/dist/rust-0.11.0-x86_64-apple-darwin.pkg
+[0.11.0-osx-x64-pkg-sig]: https://static.rust-lang.org/dist/rust-0.11.0-x86_64-apple-darwin.pkg.asc
+[0.11.0-osx-x32-pkg]: https://static.rust-lang.org/dist/rust-0.11.0-i686-apple-darwin.pkg
+[0.11.0-osx-x32-pkg-sig]: https://static.rust-lang.org/dist/rust-0.11.0-i686-apple-darwin.pkg.asc
+[0.11.0-osx-x64-tar]: https://static.rust-lang.org/dist/rust-0.11.0-x86_64-apple-darwin.tar.gz
+[0.11.0-osx-x64-tar-sig]: https://static.rust-lang.org/dist/rust-0.11.0-x86_64-apple-darwin.tar.gz.asc
+[0.11.0-osx-x32-tar]: https://static.rust-lang.org/dist/rust-0.11.0-i686-apple-darwin.tar.gz
+[0.11.0-osx-x32-tar-sig]: https://static.rust-lang.org/dist/rust-0.11.0-i686-apple-darwin.tar.gz.asc
 [0.11.0-docs]: http://doc.rust-lang.org/0.11.0/index.html
 
 ## 0.10
@@ -438,37 +333,24 @@ longer explanation in the [[detailed release notes|Doc detailed release notes]].
 - [Mac OS X i686 tarball][0.10-osx-x32-tar] ([signature][0.10-osx-x32-tar-sig])
 - [Documentation][0.10-docs]
 
-[0.10-announce]:
-  https://mail.mozilla.org/pipermail/rust-dev/2014-April/009387.html
+[0.10-announce]: https://mail.mozilla.org/pipermail/rust-dev/2014-April/009387.html
 [0.10-notes]: https://github.com/mozilla/rust/blob/0.10/RELEASES.txt
 [0.10-tar]: https://static.rust-lang.org/dist/rust-0.10.tar.gz
 [0.10-tar-sig]: https://static.rust-lang.org/dist/rust-0.10.tar.gz.asc
 [0.10-exe]: https://static.rust-lang.org/dist/rust-0.10-install.exe
 [0.10-exe-sig]: https://static.rust-lang.org/dist/rust-0.10-install.exe.asc
-[0.10-linux-x64]:
-  https://static.rust-lang.org/dist/rust-0.10-x86_64-unknown-linux-gnu.tar.gz
-[0.10-linux-x64-sig]:
-  https://static.rust-lang.org/dist/rust-0.10-x86_64-unknown-linux-gnu.tar.gz.asc
-[0.10-linux-x32]:
-  https://static.rust-lang.org/dist/rust-0.10-i686-unknown-linux-gnu.tar.gz
-[0.10-linux-x32-sig]:
-  https://static.rust-lang.org/dist/rust-0.10-i686-unknown-linux-gnu.tar.gz.asc
-[0.10-osx-x64-pkg]:
-  https://static.rust-lang.org/dist/rust-0.10-x86_64-apple-darwin.pkg
-[0.10-osx-x64-pkg-sig]:
-  https://static.rust-lang.org/dist/rust-0.10-x86_64-apple-darwin.pkg.asc
-[0.10-osx-x32-pkg]:
-  https://static.rust-lang.org/dist/rust-0.10-i686-apple-darwin.pkg
-[0.10-osx-x32-pkg-sig]:
-  https://static.rust-lang.org/dist/rust-0.10-i686-apple-darwin.pkg.asc
-[0.10-osx-x64-tar]:
-  https://static.rust-lang.org/dist/rust-0.10-x86_64-apple-darwin.tar.gz
-[0.10-osx-x64-tar-sig]:
-  https://static.rust-lang.org/dist/rust-0.10-x86_64-apple-darwin.tar.gz.asc
-[0.10-osx-x32-tar]:
-  https://static.rust-lang.org/dist/rust-0.10-i686-apple-darwin.tar.gz
-[0.10-osx-x32-tar-sig]:
-  https://static.rust-lang.org/dist/rust-0.10-i686-apple-darwin.tar.gz.asc
+[0.10-linux-x64]: https://static.rust-lang.org/dist/rust-0.10-x86_64-unknown-linux-gnu.tar.gz
+[0.10-linux-x64-sig]: https://static.rust-lang.org/dist/rust-0.10-x86_64-unknown-linux-gnu.tar.gz.asc
+[0.10-linux-x32]: https://static.rust-lang.org/dist/rust-0.10-i686-unknown-linux-gnu.tar.gz
+[0.10-linux-x32-sig]: https://static.rust-lang.org/dist/rust-0.10-i686-unknown-linux-gnu.tar.gz.asc
+[0.10-osx-x64-pkg]: https://static.rust-lang.org/dist/rust-0.10-x86_64-apple-darwin.pkg
+[0.10-osx-x64-pkg-sig]: https://static.rust-lang.org/dist/rust-0.10-x86_64-apple-darwin.pkg.asc
+[0.10-osx-x32-pkg]: https://static.rust-lang.org/dist/rust-0.10-i686-apple-darwin.pkg
+[0.10-osx-x32-pkg-sig]: https://static.rust-lang.org/dist/rust-0.10-i686-apple-darwin.pkg.asc
+[0.10-osx-x64-tar]: https://static.rust-lang.org/dist/rust-0.10-x86_64-apple-darwin.tar.gz
+[0.10-osx-x64-tar-sig]: https://static.rust-lang.org/dist/rust-0.10-x86_64-apple-darwin.tar.gz.asc
+[0.10-osx-x32-tar]: https://static.rust-lang.org/dist/rust-0.10-i686-apple-darwin.tar.gz
+[0.10-osx-x32-tar-sig]: https://static.rust-lang.org/dist/rust-0.10-i686-apple-darwin.tar.gz.asc
 [0.10-docs]: http://doc.rust-lang.org/doc/0.10/index.html
 
 ## 0.9
@@ -479,8 +361,7 @@ longer explanation in the [[detailed release notes|Doc detailed release notes]].
 - [Windows installer][0.9-exe] ([signature][0.9-exe-sig])
 - [Documentation][0.9-docs]
 
-[0.9-announce]:
-  https://mail.mozilla.org/pipermail/rust-dev/2014-January/007753.html
+[0.9-announce]: https://mail.mozilla.org/pipermail/rust-dev/2014-January/007753.html
 [0.9-notes]: https://github.com/mozilla/rust/blob/0.9/RELEASES.txt
 [0.9-tar]: https://static.rust-lang.org/dist/rust-0.9.tar.gz
 [0.9-tar-sig]: https://static.rust-lang.org/dist/rust-0.9.tar.gz.asc
@@ -505,20 +386,16 @@ longer explanation in the [[detailed release notes|Doc detailed release notes]].
 - [Standard library docs][0.8-std]
 - [Extra library docs][0.8-extra]
 
-[0.8-announce]:
-  https://mail.mozilla.org/pipermail/rust-dev/2013-September/005804.html
+[0.8-announce]: https://mail.mozilla.org/pipermail/rust-dev/2013-September/005804.html
 [0.8-notes]: https://github.com/mozilla/rust/blob/0.8/RELEASES.txt
 [0.8-tar]: https://static.rust-lang.org/dist/rust-0.8.tar.gz
 [0.8-tar-sig]: https://static.rust-lang.org/dist/rust-0.8.tar.gz.asc
 [0.8-exe]: https://static.rust-lang.org/dist/rust-0.8-install.exe
 [0.8-exe-sig]: https://static.rust-lang.org/dist/rust-0.8-install.exe.asc
 [0.8-tutorial]: http://doc.rust-lang.org/doc/0.8/tutorial.html
-[0.8-tutorial-borrowed-ptr]:
-  http://doc.rust-lang.org/doc/0.8/tutorial-borrowed-ptr.html
-[0.8-tutorial-conditions]:
-  http://doc.rust-lang.org/doc/0.8/tutorial-conditions.html
-[0.8-tutorial-container]:
-  http://doc.rust-lang.org/doc/0.8/tutorial-container.html
+[0.8-tutorial-borrowed-ptr]: http://doc.rust-lang.org/doc/0.8/tutorial-borrowed-ptr.html
+[0.8-tutorial-conditions]: http://doc.rust-lang.org/doc/0.8/tutorial-conditions.html
+[0.8-tutorial-container]: http://doc.rust-lang.org/doc/0.8/tutorial-container.html
 [0.8-tutorial-ffi]: http://doc.rust-lang.org/doc/0.8/tutorial-ffi.html
 [0.8-tutorial-macros]: http://doc.rust-lang.org/doc/0.8/tutorial-macros.html
 [0.8-tutorial-rustpkg]: http://doc.rust-lang.org/doc/0.8/tutorial-rustpkg.html
@@ -540,8 +417,7 @@ longer explanation in the [[detailed release notes|Doc detailed release notes]].
 - [Standard library docs][0.7-std]
 - [Extra library docs][0.7-extra]
 
-[0.7-announce]:
-  https://mail.mozilla.org/pipermail/rust-dev/2013-July/004667.html
+[0.7-announce]: https://mail.mozilla.org/pipermail/rust-dev/2013-July/004667.html
 [0.7-notes]: https://github.com/mozilla/rust/blob/release-0.7/RELEASES.txt
 [0.7-tar]: https://static.rust-lang.org/dist/rust-0.7.tar.gz
 [0.7-tar-sig]: https://static.rust-lang.org/dist/rust-0.7.tar.gz.asc
@@ -564,8 +440,7 @@ longer explanation in the [[detailed release notes|Doc detailed release notes]].
 - [Core library docs][0.6-core]
 - [Standard library docs][0.6-std]
 
-[0.6-announce]:
-  https://mail.mozilla.org/pipermail/rust-dev/2013-April/003427.html
+[0.6-announce]: https://mail.mozilla.org/pipermail/rust-dev/2013-April/003427.html
 [0.6-notes]: https://github.com/mozilla/rust/blob/release-0.6/RELEASES.txt
 [0.6-tar]: https://static.rust-lang.org/dist/rust-0.6.tar.gz
 [0.6-tar-sig]: https://static.rust-lang.org/dist/rust-0.6.tar.gz.asc
@@ -588,8 +463,7 @@ longer explanation in the [[detailed release notes|Doc detailed release notes]].
 - [Core library docs][0.5-core]
 - [Standard library docs][0.5-std]
 
-[0.5-announce]:
-  https://mail.mozilla.org/pipermail/rust-dev/2012-December/002787.html
+[0.5-announce]: https://mail.mozilla.org/pipermail/rust-dev/2012-December/002787.html
 [0.5-notes]: https://github.com/mozilla/rust/blob/release-0.5/RELEASES.txt
 [0.5-tar]: https://static.rust-lang.org/dist/rust-0.5.tar.gz
 [0.5-tar-sig]: https://static.rust-lang.org/dist/rust-0.5.tar.gz.asc
@@ -612,8 +486,7 @@ longer explanation in the [[detailed release notes|Doc detailed release notes]].
 - [Core library docs][0.4-core]
 - [Standard library docs][0.4-std]
 
-[0.4-announce]:
-  https://mail.mozilla.org/pipermail/rust-dev/2012-October/002489.html
+[0.4-announce]: https://mail.mozilla.org/pipermail/rust-dev/2012-October/002489.html
 [0.4-notes]: https://github.com/mozilla/rust/blob/release-0.4/RELEASES.txt
 [0.4-tar]: https://static.rust-lang.org/dist/rust-0.4.tar.gz
 [0.4-tar-sig]: https://static.rust-lang.org/dist/rust-0.4.tar.gz.asc
@@ -631,8 +504,7 @@ longer explanation in the [[detailed release notes|Doc detailed release notes]].
 - [Release notes][0.3.1-notes]
 - [Source code][0.3.1-tar] ([signature][0.3.1-tar-sig])
 
-[0.3.1-announce]:
-  https://mail.mozilla.org/pipermail/rust-dev/2012-July/002152.html
+[0.3.1-announce]: https://mail.mozilla.org/pipermail/rust-dev/2012-July/002152.html
 [0.3.1-notes]: https://github.com/mozilla/rust/blob/release-0.3.1/RELEASES.txt
 [0.3.1-tar]: https://static.rust-lang.org/dist/rust-0.3.1.tar.gz
 [0.3.1-tar-sig]: https://static.rust-lang.org/dist/rust-0.3.1.tar.gz.asc
@@ -650,8 +522,7 @@ This was an OS X bugfix release.
 - [Core library docs][0.3-core]
 - [Standard library docs][0.3-std]
 
-[0.3-announce]:
-  https://mail.mozilla.org/pipermail/rust-dev/2012-July/002087.html
+[0.3-announce]: https://mail.mozilla.org/pipermail/rust-dev/2012-July/002087.html
 [0.3-notes]: https://github.com/mozilla/rust/blob/release-0.3/RELEASES.txt
 [0.3-tar]: https://static.rust-lang.org/dist/rust-0.3.tar.gz
 [0.3-tar-sig]: https://static.rust-lang.org/dist/rust-0.3.tar.gz.asc
@@ -670,8 +541,7 @@ This was an OS X bugfix release.
 - [Source code][0.2-tar] ([signature][0.2-tar-sig])
 - [Windows installer][0.2-exe] ([signature][0.2-exe-sig])
 
-[0.2-announce]:
-  https://mail.mozilla.org/pipermail/rust-dev/2012-March/001511.html
+[0.2-announce]: https://mail.mozilla.org/pipermail/rust-dev/2012-March/001511.html
 [0.2-notes]: https://github.com/mozilla/rust/blob/release-0.2/RELEASES.txt
 [0.2-tar]: https://static.rust-lang.org/dist/rust-0.2.tar.gz
 [0.2-tar-sig]: https://static.rust-lang.org/dist/rust-0.2.tar.gz.asc
@@ -684,8 +554,7 @@ This was an OS X bugfix release.
 - [Release notes][0.1-notes]
 - [Source code][0.1-tar] ([signature][0.1-tar-sig])
 
-[0.1-announce]:
-  https://mail.mozilla.org/pipermail/rust-dev/2012-January/001256.html
+[0.1-announce]: https://mail.mozilla.org/pipermail/rust-dev/2012-January/001256.html
 [0.1-notes]: https://github.com/mozilla/rust/blob/release-0.1/RELEASES.txt
 [0.1-tar]: https://static.rust-lang.org/dist/rust-0.1.tar.gz
 [0.1-tar-sig]: https://static.rust-lang.org/dist/rust-0.1.tar.gz.asc

--- a/rfc-merge-procedure.md
+++ b/rfc-merge-procedure.md
@@ -26,10 +26,8 @@ This is a tracking issue for the RFC "XXX" (rust-lang/rfcs#NNN).
 - [ ] Adjust documentation ([see instructions on rustc-guide][doc-guide])
 - [ ] Stabilization PR ([see instructions on rustc-guide][stabilization-guide])
 
-[stabilization-guide]:
-  https://rust-lang.github.io/rustc-guide/stabilization_guide.html#stabilization-pr
-[doc-guide]:
-  https://rust-lang.github.io/rustc-guide/stabilization_guide.html#documentation-prs
+[stabilization-guide]: https://rust-lang.github.io/rustc-guide/stabilization_guide.html#stabilization-pr
+[doc-guide]: https://rust-lang.github.io/rustc-guide/stabilization_guide.html#documentation-prs
 
 **Unresolved questions:**
 

--- a/rustc-bug-fix-procedure.md
+++ b/rustc-bug-fix-procedure.md
@@ -239,8 +239,7 @@ automatically generates the lower-case string; so searching for
 The first reference you will likely find is the lint definition [in
 `librustc/lint/builtin.rs` that resembles this][defsource]:
 
-[defsource]:
-  https://github.com/rust-lang/rust/blob/085d71c3efe453863739c1fb68fd9bd1beff214f/src/librustc/lint/builtin.rs#L171-L175
+[defsource]: https://github.com/rust-lang/rust/blob/085d71c3efe453863739c1fb68fd9bd1beff214f/src/librustc/lint/builtin.rs#L171-L175
 
 ```rust
 declare_lint! {
@@ -254,8 +253,7 @@ This `declare_lint!` macro creates the relevant data structures. Remove it. You
 will also find that there is a mention of `OVERLAPPING_INHERENT_IMPLS` later in
 the file as [part of a `lint_array!`][lintarraysource]; remove it too,
 
-[lintarraysource]:
-  https://github.com/rust-lang/rust/blob/085d71c3efe453863739c1fb68fd9bd1beff214f/src/librustc/lint/builtin.rs#L252-L290
+[lintarraysource]: https://github.com/rust-lang/rust/blob/085d71c3efe453863739c1fb68fd9bd1beff214f/src/librustc/lint/builtin.rs#L252-L290
 
 Next, you see see [a reference to `OVERLAPPING_INHERENT_IMPLS` in
 `librustc_lint/lib.rs`][futuresource]. This defining the lint as a "future
@@ -326,14 +324,10 @@ can just be removed.
 
 Open a PR. =)
 
-[addlintsource]:
-  https://github.com/rust-lang/rust/blob/085d71c3efe453863739c1fb68fd9bd1beff214f/src/librustc_typeck/coherence/inherent.rs#L300-L303
-[futuresource]:
-  https://github.com/rust-lang/rust/blob/085d71c3efe453863739c1fb68fd9bd1beff214f/src/librustc_lint/lib.rs#L202-L205
+[addlintsource]: https://github.com/rust-lang/rust/blob/085d71c3efe453863739c1fb68fd9bd1beff214f/src/librustc_typeck/coherence/inherent.rs#L300-L303
+[futuresource]: https://github.com/rust-lang/rust/blob/085d71c3efe453863739c1fb68fd9bd1beff214f/src/librustc_lint/lib.rs#L202-L205
 
 <!-- -Links--------------------------------------------------------------------- -->
 
-[rfc 1122]:
-  https://github.com/rust-lang/rfcs/blob/master/text/1122-language-semver.md
-[breaking-change-issue]:
-  https://gist.github.com/nikomatsakis/631ec8b4af9a18b5d062d9d9b7d3d967
+[rfc 1122]: https://github.com/rust-lang/rfcs/blob/master/text/1122-language-semver.md
+[breaking-change-issue]: https://gist.github.com/nikomatsakis/631ec8b4af9a18b5d062d9d9b7d3d967

--- a/rustc-team-maintenance.md
+++ b/rustc-team-maintenance.md
@@ -50,11 +50,9 @@ Remove the team member from any and all places:
 - email aliases (as above)
 - [team roster page][team-roster]
 
-[homu]:
-  https://github.com/alexcrichton/rust-central-station/blob/master/homu.toml.template
+[homu]: https://github.com/alexcrichton/rust-central-station/blob/master/homu.toml.template
 [team-roster]: https://github.com/rust-lang/rust-www/blob/master/_data/team.yml
 [gh-team]: https://github.com/orgs/rust-lang/teams
 [gh-nursery-team]: https://github.com/orgs/rust-lang-nursery/teams
 [highfive]: https://github.com/nrc/highfive/tree/master/highfive/configs
-[rfcbot-example]:
-  https://github.com/anp/rfcbot-rs/commit/cd54241359cf65742ed5a0fba58ea5114de06f2b#diff-100115fcbdda685c37ba8f73727b0987
+[rfcbot-example]: https://github.com/anp/rfcbot-rs/commit/cd54241359cf65742ed5a0fba58ea5114de06f2b#diff-100115fcbdda685c37ba8f73727b0987

--- a/triage-procedure.md
+++ b/triage-procedure.md
@@ -27,26 +27,16 @@ title: Triage Procedure
   long time
 - [S-inactive-closed] - Closed due to inactivity.
 
-[s-waiting-on-author]:
-  https://github.com/rust-lang/rust/pulls?q=is%3Aopen+is%3Apr+sort%3Aupdated-asc+label%3AS-waiting-on-author
-[s-waiting-on-review]:
-  https://github.com/rust-lang/rust/pulls?q=is%3Aopen+is%3Apr+sort%3Aupdated-asc+label%3AS-waiting-on-review
-[s-waiting-on-team]:
-  https://github.com/rust-lang/rust/pulls?q=is%3Aopen+is%3Apr+label%3AS-waiting-on-team+sort%3Aupdated-desc
-[s-waiting-on-bors]:
-  https://github.com/rust-lang/rust/pulls?q=is%3Aopen+is%3Apr+label%3AS-waiting-on-bors+sort%3Aupdated-asc
-[s-waiting-on-crater]:
-  https://github.com/rust-lang/rust/pulls?q=is%3Aopen+is%3Apr+label%3AS-waiting-on-crater+sort%3Aupdated-asc
-[s-waiting-on-bikeshed]:
-  https://github.com/rust-lang/rust/pulls?q=is%3Aopen+is%3Apr+label%3AS-waiting-on-bikeshed+sort%3Aupdated-asc
-[s-waiting-on-perf]:
-  https://github.com/rust-lang/rust/pulls?q=is%3Aopen+is%3Apr+label%3AS-waiting-on-perf+sort%3Aupdated-asc
-[s-blocked]:
-  https://github.com/rust-lang/rust/pulls?q=is%3Aopen+is%3Apr+label%3AS-blocked+sort%3Aupdated-asc
-[s-blocked-closed]:
-  https://github.com/rust-lang/rust/pulls?q=is%3Apr+label%3AS-blocked-closed+sort%3Aupdated-asc
-[s-inactive-closed]:
-  https://github.com/rust-lang/rust/pulls?q=is%3Apr+label%3AS-inactive-closed+sort%3Aupdated-asc
+[s-waiting-on-author]: https://github.com/rust-lang/rust/pulls?q=is%3Aopen+is%3Apr+sort%3Aupdated-asc+label%3AS-waiting-on-author
+[s-waiting-on-review]: https://github.com/rust-lang/rust/pulls?q=is%3Aopen+is%3Apr+sort%3Aupdated-asc+label%3AS-waiting-on-review
+[s-waiting-on-team]: https://github.com/rust-lang/rust/pulls?q=is%3Aopen+is%3Apr+label%3AS-waiting-on-team+sort%3Aupdated-desc
+[s-waiting-on-bors]: https://github.com/rust-lang/rust/pulls?q=is%3Aopen+is%3Apr+label%3AS-waiting-on-bors+sort%3Aupdated-asc
+[s-waiting-on-crater]: https://github.com/rust-lang/rust/pulls?q=is%3Aopen+is%3Apr+label%3AS-waiting-on-crater+sort%3Aupdated-asc
+[s-waiting-on-bikeshed]: https://github.com/rust-lang/rust/pulls?q=is%3Aopen+is%3Apr+label%3AS-waiting-on-bikeshed+sort%3Aupdated-asc
+[s-waiting-on-perf]: https://github.com/rust-lang/rust/pulls?q=is%3Aopen+is%3Apr+label%3AS-waiting-on-perf+sort%3Aupdated-asc
+[s-blocked]: https://github.com/rust-lang/rust/pulls?q=is%3Aopen+is%3Apr+label%3AS-blocked+sort%3Aupdated-asc
+[s-blocked-closed]: https://github.com/rust-lang/rust/pulls?q=is%3Apr+label%3AS-blocked-closed+sort%3Aupdated-asc
+[s-inactive-closed]: https://github.com/rust-lang/rust/pulls?q=is%3Apr+label%3AS-inactive-closed+sort%3Aupdated-asc
 
 ## Procedure:
 
@@ -65,8 +55,7 @@ with something like "Ping from triage ..."."
 All PRs that have no assignee (except rollups) should be assigned to a random
 member of the responsible team.
 
-[unassigned prs]:
-  https://github.com/rust-lang/rust/pulls?q=is%3Aopen+is%3Apr+no%3Aassignee
+[unassigned prs]: https://github.com/rust-lang/rust/pulls?q=is%3Aopen+is%3Apr+no%3Aassignee
 
 ### [Unlabeled PRs]
 
@@ -82,8 +71,7 @@ submitter as a regular contributor, leave a comment saying something like
 
 At this point, all PRs must have a tag applied.
 
-[unlabeled prs]:
-  https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen%20is%3Apr%20sort%3Aupdated-asc%20-label%3AS-waiting-on-author%20-label%3AS-waiting-on-team%20-label%3AS-waiting-on-bors%20-label%3AS-waiting-on-crater%20-label%3AS-waiting-on-team%20-label%3AS-waiting-on-review%20-label%3AS-blocked%20-label%3AS-waiting-on-bikeshed%20-label%3AS-waiting-on-fcp%20-label%3AS-waiting-on-perf
+[unlabeled prs]: https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen%20is%3Apr%20sort%3Aupdated-asc%20-label%3AS-waiting-on-author%20-label%3AS-waiting-on-team%20-label%3AS-waiting-on-bors%20-label%3AS-waiting-on-crater%20-label%3AS-waiting-on-team%20-label%3AS-waiting-on-review%20-label%3AS-blocked%20-label%3AS-waiting-on-bikeshed%20-label%3AS-waiting-on-fcp%20-label%3AS-waiting-on-perf
 
 ### [S-waiting-on-author PRs][s-waiting-on-author]
 
@@ -307,8 +295,7 @@ if they require assistance, and inform them that after 14 days this issue will
 be made available to anyone. After 14 days re-add the help tag and deassign them
 if necessary.
 
-[list of untagged issues]:
-  https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20sort%3Acreated-asc%20-label%3AC-feature-request%20-label%3AC-enhancement%20-label%3AC-cleanup%20-label%3AC-bug%20-label%3AC-tracking-issue%20-label%3AC-future-compatibility%20-label%3AC-question%20-label%3AC-feature-accepted
+[list of untagged issues]: https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20sort%3Acreated-asc%20-label%3AC-feature-request%20-label%3AC-enhancement%20-label%3AC-cleanup%20-label%3AC-bug%20-label%3AC-tracking-issue%20-label%3AC-future-compatibility%20-label%3AC-question%20-label%3AC-feature-accepted
 
 # State Of Rust Triage
 


### PR DESCRIPTION
`prettier --write --prose-wrap always *.md` splits reference links across lines, breaking them.

`preserve` should be used instead:
```bash
$ prettier --write --prose-wrap preserve *.md
```