### PR TITLE
Fix off-by-one in toolstate breakage week start.

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -15,7 +15,7 @@ const addRelease = (kind, incr, tools_week) => {
 
     if (tools_week === true) {
         const noBreakagesTo = releaseDate.clone().day(2);
-        const noBreakagesFrom = noBreakagesTo.clone().subtract(1, 'week');
+        const noBreakagesFrom = noBreakagesTo.clone().subtract(6, 'day');
         const toDate = noBreakagesTo.format(dateFormat);
         const fromDate = noBreakagesFrom.format(dateFormat);
 


### PR DESCRIPTION
IIUC, based on the rules in `checktools.sh`, Tue before release is 41, Wed is 0.  The check is `-ge 35`.  35 is the *Wednesday* of the prior week.  The current forge site says "no tools breakage starts Aug 6", which is Tuesday. But a tool broke today, so I believe it starts tomorrow.
