### PR TITLE
Removed unneeded JS query

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -29,8 +29,6 @@ const addRelease = (kind, incr, tools_week) => {
     }
 };
 
-document.querySelector(".tools-no-breakages-header").classList.remove("hidden");
-
 addRelease("stable", 0, false);
 addRelease("beta", 1, true);
 addRelease("nightly", 2, true);


### PR DESCRIPTION
This line from the old code somehow made it through, and breaks the JS currently as `.tools-no-breakages-header` no longer exists.