### PR TITLE
Actually fixed JS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
 before_script:
   # TODO: Installing mdbook from crates.io takes quite a long time. This could
   # be reduced by downloading the release from GitHub directly.
-  - cargo install mdbook --vers '^0.3.0' --force
+  - mdbook -V || cargo install mdbook --vers '^0.3.0'
 script:
   - mdbook build
 branches:

--- a/js/index.js
+++ b/js/index.js
@@ -1,31 +1,26 @@
 // Rust 1.5.0 was released on 2015-12-10
 const epochDate = moment.utc("2015-12-10");
 const epochRelease = 5;
+const dateFormat = "MMMM Do YYYY";
 
 const newReleases = Math.floor(moment.utc().diff(epochDate, "weeks") / 6);
 
 const addRelease = (kind, incr, tools_week) => {
-    let releaseNumber = epochRelease + newReleases + incr;
-    let releaseDate = epochDate.clone().add((newReleases + incr) * 6, "weeks");
+    const releaseNumber = epochRelease + newReleases + incr;
+    const displayVersion = `1.${releaseNumber}`
+    const releaseDate = epochDate.clone().add((newReleases + incr) * 6, "weeks");
 
-    let out = "";
-    out += '<div class="release">';
-    out += '<div class="release-kind">Current ' + kind + '</div>';
-    out += '<div class="release-number">1.' + releaseNumber + '</div>';
-    out += '<div class="release-date">' + releaseDate.format("MMMM Do YYYY") + '</div>';
-    out += '</div>';
-    document.querySelector(".releases").innerHTML += out;
+    document.querySelector(`#${kind}-version`).textContent = displayVersion;
+    document.querySelector(`#${kind}-release-date`).textContent = releaseDate.format(dateFormat);
 
     if (tools_week === true) {
-        let noBreakagesTo = releaseDate.clone().day(2);
-        let noBreakagesFrom = noBreakagesTo.clone().subtract(1, 'week');
+        const noBreakagesTo = releaseDate.clone().day(2);
+        const noBreakagesFrom = noBreakagesTo.clone().subtract(1, 'week');
+        const toDate = noBreakagesTo.format(dateFormat);
+        const fromDate = noBreakagesFrom.format(dateFormat);
 
-        let out = "";
-        out += '<div class="tool-no-breakage">';
-        out += '<div class="tool-no-breakage-cycle">1.' + releaseNumber + ' cycle</div>';
-        out += '<div class="tool-no-breakage-dates">' + noBreakagesFrom.format("MMMM Do YYYY") + ' &rarr; ' + noBreakagesTo.format("MMMM Do YYYY") + '</div>';
-        out += '</div>';
-        document.querySelector(".tools-no-breakages").innerHTML += out;
+        document.querySelector(`#${kind}-cycle`).textContent = displayVersion;
+        document.querySelector(`#${kind}-timespan`).textContent = `${toDate} → ${fromDate}`;
     }
 };
 


### PR DESCRIPTION
I made a mistake, apparently the original `js/index.js` changes were lost in all the rebasing. This adds the correct and tested JS. This also adds caching for mdbook as the builds are far too long.