### PR TITLE
Rustfmt's to field points to rustfmt-preview, instead of rustfmt.

### DIFF
--- a/src/infra/channel-layout.md
+++ b/src/infra/channel-layout.md
@@ -60,7 +60,7 @@ There are then a number of top level sections (tables) which are:
   Typically renames are used when a package leaves its preview state and is
   considered to be release quality. For example, the actual package for
   `rustfmt` is called `rustfmt-preview` but since its release there has been a
-  `renames.rustfmt` table whose `to` field is `rustfmt`. When the user runs
+  `renames.rustfmt` table whose `to` field is `rustfmt-preview`. When the user runs
   `rustup component add rustfmt` the name is automatically translated to
   `rustfmt-preview` and when the user runs `rustup component list` then
   `rustfmt-preview` is automatically renamed back to `rustfmt` for display to


### PR DESCRIPTION
Within the current channel-layout documentation, the documentation states that
the table `renames.rustfmt` has a `to` field with the text `rustfmt`.
The actual table [e1] however contains the text `rustfmt-preview`.
This makes sense as the rename would otherwise point to itself.

[e1] An example of an actual table can be found here: http://static.rust-lang.org/dist/channel-rust-1.38.0.toml at line 11919 which states:
```toml
[renames.rustfmt]
to = "rustfmt-preview"
```