### PR TITLE
Add missing Zulip link to steering-meeting document

### DIFF
--- a/src/compiler/steering-meeting.md
+++ b/src/compiler/steering-meeting.md
@@ -38,6 +38,7 @@ time. The meetings take place in the #t-compiler stream on the
 
 [c]: https://rust-lang.github.io/compiler-team/#meeting-calendar
 [ir]: https://blog.rust-lang.org/inside-rust/
+[z]: https://rust-lang.zulipchat.com
 
 [rust-lang/rust#54818]: https://github.com/rust-lang/rust/issues/54818
 [compiler-team website]: https://rust-lang.github.io/compiler-team/about/triage-meeting/


### PR DESCRIPTION
r? @nikomatsakis 

The link could also be directly to the t-compiler stream. Let me know if you prefer that.