### PR TITLE
Fix JS error on other pages and use Standard formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,44 @@
 Welcome to the [Rust Forge]! Rust Forge serves as a repository of supplementary
 documentation useful for members of [The Rust Programming Language].
 
+[the rust programming language]: https://rust-lang.org
+[rust forge]: https://forge.rust-lang.org
+
 # Building
+
 ```
 $ mdbook build
 ```
 
 # Development
+
 When developing it's recommended to use the `serve` command to launch a local
 server to allow you to easily see and update changes you make.
+
 ```
 $ mdbook serve
 ```
 
-[The Rust Programming Language]: https://rust-lang.org
-[Rust Forge]: https://forge.rust-lang.org
+## JavaScript
 
+Forge uses JavaScript to display dates for releases and "no tools breakage
+week". When making modifications to the JavaScript make sure it matches the
+[standard] style. You can install `standard` and automatically format the code
+using the following commands.
+
+[standard]: https://standardjs.com/index.html
+
+### Install
+
+```bash
+# With Yarn
+yarn global add standard
+# With NPM
+npm install --global standard
+```
+
+### Formatting
+
+```bash
+standard --fix js/
+```

--- a/js/index.js
+++ b/js/index.js
@@ -1,29 +1,32 @@
+/* global moment */
+
 // Rust 1.5.0 was released on 2015-12-10
-const epochDate = moment.utc("2015-12-10");
-const epochRelease = 5;
-const dateFormat = "MMMM Do YYYY";
+const EPOCH_DATE = moment.utc('2015-12-10')
+const EPOCH_RELEASE = 5
+const DATE_FORMAT = 'MMMM Do YYYY'
+const newReleases = Math.floor(moment.utc().diff(EPOCH_DATE, 'weeks') / 6)
 
-const newReleases = Math.floor(moment.utc().diff(epochDate, "weeks") / 6);
+function addRelease (kind, incr, toolsWeek) {
+  const releaseNumber = EPOCH_RELEASE + newReleases + incr
+  const displayVersion = `1.${releaseNumber}`
+  const releaseDate = EPOCH_DATE.clone().add((newReleases + incr) * 6, 'weeks')
 
-const addRelease = (kind, incr, tools_week) => {
-    const releaseNumber = epochRelease + newReleases + incr;
-    const displayVersion = `1.${releaseNumber}`
-    const releaseDate = epochDate.clone().add((newReleases + incr) * 6, "weeks");
+  document.querySelector(`#${kind}-version`).textContent = displayVersion
+  document.querySelector(`#${kind}-release-date`).textContent = `${releaseDate.format(DATE_FORMAT)} UTC`
 
-    document.querySelector(`#${kind}-version`).textContent = displayVersion;
-    document.querySelector(`#${kind}-release-date`).textContent = releaseDate.format(dateFormat);
+  if (toolsWeek) {
+    const noBreakagesTo = releaseDate.clone().day(2)
+    const noBreakagesFrom = noBreakagesTo.clone().subtract(6, 'days')
+    const toDate = noBreakagesTo.format(DATE_FORMAT)
+    const fromDate = noBreakagesFrom.format(DATE_FORMAT)
 
-    if (tools_week === true) {
-        const noBreakagesTo = releaseDate.clone().day(2);
-        const noBreakagesFrom = noBreakagesTo.clone().subtract(6, 'day');
-        const toDate = noBreakagesTo.format(dateFormat);
-        const fromDate = noBreakagesFrom.format(dateFormat);
+    document.querySelector(`#${kind}-cycle`).textContent = displayVersion
+    document.querySelector(`#${kind}-timespan`).textContent = `${fromDate} → ${toDate}`
+  }
+}
 
-        document.querySelector(`#${kind}-cycle`).textContent = displayVersion;
-        document.querySelector(`#${kind}-timespan`).textContent = `${fromDate} → ${toDate}`;
-    }
-};
-
-addRelease("stable", 0, false);
-addRelease("beta", 1, true);
-addRelease("nightly", 2, true);
+if (document.querySelector('#current-release-versions')) {
+  addRelease('stable', 0, false)
+  addRelease('beta', 1, true)
+  addRelease('nightly', 2, true)
+}

--- a/src/README.md
+++ b/src/README.md
@@ -10,6 +10,9 @@ file an issue or PR on the [Rust Forge GitHub].
 <!-- All `<span id="..."></span>` elements are filled at run time when a reader
 visits the website. Please refer to `js/index.js` for how these values
 are generated.
+
+Avoid changing the "Current Release Versions" without also updating the selector
+in `js/index.js.
 -->
 
 ### Current Release Versions


### PR DESCRIPTION
The JS current errors on other pages because it can't find the `stable-version` element. This has no actual effect in practice, but is annoying to have an error in the console and would prevent us adding potentially more JavaScript for other pages in the future.