### PR TITLE
An initial section for libs docs

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -36,6 +36,8 @@
 - [Language](./lang/README.md)
     - [RFC Merge Procedure](./lang/rfc-merge-procedure.md)
     - [Triage Meeting Procedure](./lang/triage-meeting-procedure.md)
+- [Libs](./libs/README.md)
+    - [Maintaining the standard library](./libs/maintaining-std.md)
 - [Release](./release/README.md)
     - [Beta Backporting](./release/beta-backporting.md)
     - [Platform Support](./release/platform-support.md)

--- a/src/libs/README.md
+++ b/src/libs/README.md
@@ -1,0 +1,3 @@
+# Libs
+This section documents meta processes by the libs team.
+

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -16,11 +16,11 @@ This document doesn't attempt to discuss best practices or good style. For that,
 
 ## If you’re ever unsure…
 
-Maintaining the standard library can feel like a daunting responsibility! Through the automated reviewer assignment you’ll find yourself dropped into a lot of new contexts.
+Maintaining the standard library can feel like a daunting responsibility! Through [`highfive`], the automated reviewer assignment, you’ll find yourself dropped into a lot of new contexts.
 
 Ping the `@rust-lang/libs` team on GitHub anytime. We’re all here to help!
 
-If you don’t think you’re the best person to review a PR then use [`bors`] to assign it to somebody else.
+If you don’t think you’re the best person to review a PR then use [`highfive`] to assign it to somebody else.
 
 ## Finding reviews waiting for your input
 
@@ -32,13 +32,13 @@ As a member of the Libs team you’ll find yourself assigned to PRs that need re
 
 ### When is an RFC needed?
 
-New unstable features don’t need an RFC before they can be merged. They do need one before they can be stabilized. New impls for already stable traits don't need an RFC. If a new unstable feature is large or has a lot of design space to explore then you might want to block merging it on an RFC.
+New unstable features don't need an RFC before they can be merged. If the feature is small, and the design space is straightforward, stabilizing it usually only requires the feature to go through FCP. Sometimes however, Libs may ask for an RFC before stabilizing.
 
 ### Is there any `unsafe`?
 
 Unsafe code blocks in the standard library need a comment explaining why they're [ok](https://doc.rust-lang.org/nomicon). There's a `tidy` lint that checks this. The unsafe code also needs to actually be ok.
 
-The rules around what's sound and what's not can be subtle. See the [Unsafe Code Guidelines WG] for current thinking, and consider pinging `@rust-lang/libs` and/or somebody from the WG if you're in any doubt.
+The rules around what's sound and what's not can be subtle. See the [Unsafe Code Guidelines WG] for current thinking, and consider pinging `@rust-lang/libs`, `@rust-lang/lang`, and/or somebody from the WG if you're in any doubt. We love debating the soundness of unsafe code, and the more eyes on it the better.
 
 ### Is that `#[inline]` right?
 
@@ -52,7 +52,6 @@ You shouldn’t need `#[inline]`:
 
 - On methods that have any generics in scope.
 - On methods on traits that don’t have a default implementation.
-- On `const` items.
 
 #### What about `#[inline(always)]`?
 
@@ -101,7 +100,7 @@ PRs shouldn’t have merge commits in them. If they become out of date with `mas
 
 ## Merging PRs
 
-PRs to `rust-lang/rust` aren’t merged manually using GitHub’s UI or by pushing remote branches. Everything goes through [`bors`].
+PRs to [`rust-lang/rust`] aren’t merged manually using GitHub’s UI or by pushing remote branches. Everything goes through [`bors`].
 
 ### When you’re confident it’ll build
 
@@ -127,6 +126,7 @@ Features can be stabilized in a PR that replaces `#[unstable]` attributes with `
 [`rust-lang/rfcs`]: https://github.com/rust-lang/rfcs
 [`rfcbot`]: https://github.com/rust-lang/rfcbot-rs
 [`bors`]: https://github.com/rust-lang/homu
+[`highfive`]: https://github.com/rust-lang/highfive
 [RFC 1023]: https://rust-lang.github.io/rfcs/1023-rebalancing-coherence.html
 [RFC 1105]: https://rust-lang.github.io/rfcs/1105-api-evolution.html
 [Everyone Poops]: http://cglab.ca/~abeinges/blah/everyone-poops

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -102,9 +102,11 @@ PRs shouldn’t have merge commits in them. If they become out of date with `mas
 
 PRs to [`rust-lang/rust`] aren’t merged manually using GitHub’s UI or by pushing remote branches. Everything goes through [`bors`].
 
-### When you’re confident it’ll build
+### When to `rollup`
 
-Consider explicitly specifying `rollup`.
+For Libs PRs, rolling up is usually fine, in particular if it's only a new unstable addition or if it only touches docs (with the exception of intra doc links which complicates things while the feature has bugs...).
+
+If a submodule is affected then probably don't `rollup`. If the feature affects perf then also avoid `rollup`.
 
 ### When there’s new public items
 

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -50,7 +50,7 @@ You should add `#[inline]`:
 
 You shouldn’t need `#[inline]`:
 
-- On methods that take a generic argument.
+- On methods that have any generics in scope.
 - On methods on traits that don’t have a default implementation.
 - On `const` items.
 

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -1,0 +1,132 @@
+# Maintaining the standard library
+
+> Everything I wish I knew before somebody gave me `r+`
+
+This document is an effort to capture some of the context needed to develop and maintain the Rust standard library. It’s goal is to help members of the Libs team share the process and experience they bring to working on the standard library so other members can benefit. It’ll probably accumulate a lot of trivia that might also be interesting to members of the wider Rust community.
+
+This document doesn't attempt to discuss best practices or good style. For that, see the [API Guidelines].
+
+## Terms
+
+- Libs. That's us! The team responsible for development and maintenance of the standard library (among other things).
+- Pull request (PR). A regular GitHub pull request against [`rust-lang/rust`].
+- Request for Comment (RFC). A formal document created in [`rust-lang/rfcs`] that introduces new features.
+- Tracking Issue. A regular issue on GitHub that’s tagged with `C-tracking-issue`.
+- Final Comment Period (FCP). Coordinated by [`rfcbot`] that gives relevant teams a chance to review RFCs and PRs.
+
+## If you’re ever unsure…
+
+Maintaining the standard library can feel like a daunting responsibility! Through the automated reviewer assignment you’ll find yourself dropped into a lot of new contexts.
+
+Ping the `@rust-lang/libs` team on GitHub anytime. We’re all here to help!
+
+If you don’t think you’re the best person to review a PR then use [`bors`] to assign it to somebody else.
+
+## Finding reviews waiting for your input
+
+Please remember to regularly check https://rfcbot.rs/. Click on any occurrence of your nickname to go to a page like https://rfcbot.rs/fcp/SimonSapin that only shows the reviews that are waiting for your input.
+
+## Reviewing PRs
+
+As a member of the Libs team you’ll find yourself assigned to PRs that need reviewing, and your input requested on issues in the Rust project.
+
+### When is a RFC needed?
+
+New unstable features don’t need a RFC before they can be merged. They do need one before they can be stabilized. New impls for already stable traits don't need a RFC. If a new unstable feature is large or has a lot of design space to explore then you might want to block merging it on a RFC.
+
+### Is there any `unsafe`?
+
+Unsafe code blocks in the standard library need a comment explaining why they're [ok](https://doc.rust-lang.org/nomicon). There's a `tidy` lint that checks this. The unsafe code also needs to actually be ok.
+
+The rules around what's sound and what's not can be subtle. See the [Unsafe Code Guidelines WG] for current thinking, and consider pinging `@rust-lang/libs` and/or somebody from the WG if you're in any doubt.
+
+### Is that `#[inline]` right?
+
+Inlining is a trade-off between potential execution speed, compile time and code size.
+
+You should add `#[inline]`:
+
+- To public, small, non-generic functions.
+
+You shouldn’t need `#[inline]`:
+
+- On methods that take a generic argument.
+- On methods on traits that don’t have a default implementation.
+- On `const` items.
+
+#### What about `#[inline(always)]`?
+
+You should just about never need `#[inline(always)]`. It may be beneficial for private helper methods that are used in a limited number of places or for trivial operators. A micro benchmark should justify the attribute.
+
+### Is there any potential breakage?
+
+Breaking changes should be avoided when possible. [RFC 1105] lays the foundations for what constitutes a breaking change. Breakage may be deemed acceptable or not based on its actual impact, which can be approximated with a `crater` run.
+
+For changes where the value is high and the impact is high too, there are strategies for minimizing the impact:
+
+- Using compiler lints to try phase out broken behavior.
+
+### Could this affect inference?
+
+New impls on public traits for public items may cause inference to break when there are generics involved.
+
+#### Are there `#[fundamental]` items involved?
+
+Blanket trait impls can't be added to `#[fundamental]` types because they have different coherence rules. That includes:
+
+- `Box<T>`
+- `Pin<T>`
+
+Also see [RFC 1023] for details.
+
+### Is there specialization involved?
+
+We try to avoid leaning on specialization too heavily, limiting its use to optimizing specific implementations. Any use of specialization that changes how methods are dispatched for external callers should be carefully considered.
+
+### Does this change drop order?
+
+Changes to collection internals may affect the order their items are dropped in. This has been accepted in the past, but should be noted.
+
+### Could `mem::replace` break assumptions?
+
+Any value behind a `&mut` reference can be replaced with a new one.
+
+### Could `mem::forget` break assumptions?
+
+Rust doesn't guarantee destructors will run, so code should avoid relying on them for safety. Remember, [everybody poops][Everybody Poops].
+
+### Is the commit log tidy?
+
+PRs shouldn’t have merge commits in them. If they become out of date with `master` then they need to be rebased.
+
+## Merging PRs
+
+PRs to `rust-lang/rust` aren’t merged manually using GitHub’s UI or by pushing remote branches. Everything goes through [`bors`].
+
+### When you’re confident it’ll build
+
+Consider explicitly specifying `rollup`.
+
+### When there’s new public items
+
+If the feature is new, then a tracking issue should be opened for it. The `issue` field on `#[unstable]` attributes should be updated with the tracking issue number.
+
+Unstable features can be merged as normal through [`bors`] once they look ready.
+
+### When there’s new trait impls
+
+There’s no way to make a trait impl `#[unstable]`, so **any PRs that add new impls for already `#[stable]` traits must go through a FCP before merging.**
+
+### When a feature is being stabilized
+
+Features can be stabilized in a PR that replaces `#[unstable]` attributes with `#[stable]` ones. The feature needs to have an accepted RFC before stabilizing. They also need to go through a FCP before merging.
+
+[API Guidelines]: https://rust-lang.github.io/api-guidelines
+[Unsafe Code Guidelines WG]: https://github.com/rust-lang/unsafe-code-guidelines
+[`rust-lang/rust`]: https://github.com/rust-lang/rust
+[`rust-lang/rfcs`]: https://github.com/rust-lang/rfcs
+[`rfcbot`]: https://github.com/rust-lang/rfcbot-rs
+[`bors`]: https://github.com/rust-lang/homu
+[RFC 1023]: https://rust-lang.github.io/rfcs/1023-rebalancing-coherence.html
+[RFC 1105]: https://rust-lang.github.io/rfcs/1105-api-evolution.html
+[Everyone Poops]: http://cglab.ca/~abeinges/blah/everyone-poops

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -191,7 +191,7 @@ PRs to [`rust-lang/rust`] aren’t merged manually using GitHub’s UI or by pus
 
 For Libs PRs, rolling up is usually fine, in particular if it's only a new unstable addition or if it only touches docs (with the exception of intra doc links which complicates things while the feature has bugs...).
 
-If a submodule is affected then probably don't `rollup`. If the feature affects perf then also avoid `rollup`.
+If a submodule is affected then probably don't `rollup`. If the feature affects perf then also avoid `rollup` -- mark it as `rollup=never`.
 
 ### When there’s new public items
 

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -169,7 +169,7 @@ Any value behind a `&mut` reference can be replaced with a new one using `mem::r
 
 #### `mem::forget`
 
-Rust doesn't guarantee destructors will run when a value is leaked (which can be done with `mem::forget`), so code should avoid relying on them for maintaining safety. Remember, [everybody poops][Everybody Poops].
+Rust doesn't guarantee destructors will run when a value is leaked (which can be done with `mem::forget`), so code should avoid relying on them for maintaining safety. Remember, [everyone poops][Everyone Poops].
 
 It's ok not to run a destructor when a value is leaked because its storage isn't deallocated or repurposed. It's generally _not_ ok not to run a destructor before deallocating or repurposing already initialized storage because [memory may be pinned][Drop guarantee]. Having said that, there can be exceptions for skipping destructors if you can guarantee there's never pinning involved.
 

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -32,13 +32,13 @@ As a member of the Libs team you’ll find yourself assigned to PRs that need re
 
 ### When is an RFC needed?
 
-New unstable features don't need an RFC before they can be merged. If the feature is small, and the design space is straightforward, stabilizing it usually only requires the feature to go through FCP. Sometimes however, Libs may ask for an RFC before stabilizing.
+New unstable features don't need an RFC before they can be merged. If the feature is small, and the design space is straightforward, stabilizing it usually only requires the feature to go through FCP. Sometimes however, you may ask for an RFC before stabilizing.
 
 ### Is there any `unsafe`?
 
 Unsafe code blocks in the standard library need a comment explaining why they're [ok](https://doc.rust-lang.org/nomicon). There's a `tidy` lint that checks this. The unsafe code also needs to actually be ok.
 
-The rules around what's sound and what's not can be subtle. See the [Unsafe Code Guidelines WG] for current thinking, and consider pinging `@rust-lang/libs`, `@rust-lang/lang`, and/or somebody from the WG if you're in any doubt. We love debating the soundness of unsafe code, and the more eyes on it the better.
+The rules around what's sound and what's not can be subtle. See the [Unsafe Code Guidelines WG] for current thinking, and consider pinging `@rust-lang/libs`, `@rust-lang/lang`, and/or somebody from the WG if you're in _any_ doubt. We love debating the soundness of unsafe code, and the more eyes on it the better!
 
 ### Is that `#[inline]` right?
 
@@ -64,6 +64,8 @@ Breaking changes should be avoided when possible. [RFC 1105] lays the foundation
 For changes where the value is high and the impact is high too, there are strategies for minimizing the impact:
 
 - Using compiler lints to try phase out broken behavior.
+
+The following sections outline some kinds of breakage that may not be obvious just from the change made to the standard library.
 
 #### Inference breaks when a second generic impl is introduced
 
@@ -161,6 +163,10 @@ Rust doesn't guarantee destructors will run when a value is leaked (which can be
 
 It's ok not to run a destructor when a value is leaked because its storage isn't deallocated or repurposed. It's generally _not_ ok not to run a destructor before deallocating or repurposing already initialized storage because [memory may be pinned][Drop guarantee]. Having said that, there can be exceptions for skipping destructors if you can guarantee there's never pinning involved.
 
+### How is performance impacted?
+
+Changes to hot code might impact performance in consumers, for better or for worse. Appropriate benchmarks should give an idea of how performance characteristics change. For changes that affect `rustc` itself, you can also do a [`rust-timer`] run.
+
 ### Is the commit log tidy?
 
 PRs shouldn’t have merge commits in them. If they become out of date with `master` then they need to be rebased.
@@ -177,7 +183,7 @@ If a submodule is affected then probably don't `rollup`. If the feature affects 
 
 ### When there’s new public items
 
-If the feature is new, then a tracking issue should be opened for it. The `issue` field on `#[unstable]` attributes should be updated with the tracking issue number.
+If the feature is new, then a tracking issue should be opened for it. Have a look at some previous [tracking issues][Libs tracking issues] to get an idea of what needs to go in there. The `issue` field on `#[unstable]` attributes should be updated with the tracking issue number.
 
 Unstable features can be merged as normal through [`bors`] once they look ready.
 
@@ -197,6 +203,8 @@ Features can be stabilized in a PR that replaces `#[unstable]` attributes with `
 [`bors`]: https://github.com/rust-lang/homu
 [`highfive`]: https://github.com/rust-lang/highfive
 [`crater`]: https://github.com/rust-lang/crater
+[`rust-timer`]: https://github.com/rust-lang-nursery/rustc-perf
+[Libs tracking issues]: https://github.com/rust-lang/rust/issues?q=label%3AC-tracking-issue+label%3AT-libs
 [Drop guarantee]: https://doc.rust-lang.org/nightly/std/pin/index.html#drop-guarantee
 [RFC 1023]: https://rust-lang.github.io/rfcs/1023-rebalancing-coherence.html
 [RFC 1105]: https://rust-lang.github.io/rfcs/1105-api-evolution.html

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -61,13 +61,23 @@ You should just about never need `#[inline(always)]`. It may be beneficial for p
 
 Breaking changes should be avoided when possible. [RFC 1105] lays the foundations for what constitutes a breaking change. Breakage may be deemed acceptable or not based on its actual impact, which can be approximated with a [`crater`] run.
 
-For changes where the value is high and the impact is high too, there are strategies for minimizing the impact:
+#### Managing breakage
+
+There are strategies for mitigating breakage depending on the impact.
+
+For changes where the value is high and the impact is high too:
 
 - Using compiler lints to try phase out broken behavior.
 
-The following sections outline some kinds of breakage that may not be obvious just from the change made to the standard library.
+If the impact isn't too high:
 
-#### Inference breaks when a second generic impl is introduced
+- Looping in maintainers of broken crates and submitting PRs to fix them.
+
+#### Trait impls break things
+
+The following sections outline some kinds of breakage from new trait impls that may not be obvious just from the change made to the standard library.
+
+##### Inference breaks when a second generic impl is introduced
 
 Rust will use the fact that there's only a single impl for a generic trait during inference. This breaks once a second impl makes the type of that generic ambiguous. Say we have:
 
@@ -98,7 +108,7 @@ will no longer compile, because we've previously been relying on inference to fi
 
 This kind of breakage can be ok, but a [`crater`] run should estimate the scope.
 
-#### Deref coercion breaks when a new impl is introduced
+##### Deref coercion breaks when a new impl is introduced
 
 Rust will use deref coercion to find a valid trait impl if the arguments don't type check directly. This only seems to occur if there's a single impl so introducing a new one may break consumers relying on deref coercion. Say we have:
 

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -173,7 +173,7 @@ Any value behind a `&mut` reference can be replaced with a new one using `mem::r
 
 Rust doesn't guarantee destructors will run when a value is leaked (which can be done with `mem::forget`), so code should avoid relying on them for maintaining safety. Remember, [everyone poops][Everyone Poops].
 
-It's ok not to run a destructor when a value is leaked because its storage isn't deallocated or repurposed. It's generally _not_ ok not to run a destructor before deallocating or repurposing already initialized storage because [memory may be pinned][Drop guarantee]. Having said that, there can be exceptions for skipping destructors if you can guarantee there's never pinning involved.
+It's ok not to run a destructor when a value is leaked because its storage isn't deallocated or repurposed. If the storage is initialized and is being deallocating or repurposing then destructors need to be run first, because [memory may be pinned][Drop guarantee]. Having said that, there can still be exceptions for skipping destructors when deallocating if you can guarantee there's never pinning involved.
 
 ### How is performance impacted?
 

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -6,6 +6,10 @@ This document is an effort to capture some of the context needed to develop and 
 
 This document doesn't attempt to discuss best practices or good style. For that, see the [API Guidelines].
 
+## Contributing
+
+If you spot anything that is outdated, under specified, missing, or just plain incorrect then feel free to open up a PR on the [`rust-lang/rust-forge`] repository!
+
 ## Terms
 
 - Libs. That's us! The team responsible for development and maintenance of the standard library (among other things).
@@ -213,6 +217,7 @@ You can find the right version to use in the `#[stable]` attribute by checking t
 [Unsafe Code Guidelines WG]: https://github.com/rust-lang/unsafe-code-guidelines
 [`rust-lang/rust`]: https://github.com/rust-lang/rust
 [`rust-lang/rfcs`]: https://github.com/rust-lang/rfcs
+[`rust-lang/rust-forge`]: https://github.com/rust-lang/rust-forge
 [`rfcbot`]: https://github.com/rust-lang/rfcbot-rs
 [`bors`]: https://github.com/rust-lang/homu
 [`highfive`]: https://github.com/rust-lang/highfive

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -30,7 +30,7 @@ Please remember to regularly check https://rfcbot.rs/. Click on any occurrence o
 
 As a member of the Libs team you’ll find yourself assigned to PRs that need reviewing, and your input requested on issues in the Rust project.
 
-### When is a RFC needed?
+### When is an RFC needed?
 
 New unstable features don’t need a RFC before they can be merged. They do need one before they can be stabilized. New impls for already stable traits don't need a RFC. If a new unstable feature is large or has a lot of design space to explore then you might want to block merging it on a RFC.
 

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -32,7 +32,7 @@ As a member of the Libs team you’ll find yourself assigned to PRs that need re
 
 ### When is an RFC needed?
 
-New unstable features don’t need a RFC before they can be merged. They do need one before they can be stabilized. New impls for already stable traits don't need a RFC. If a new unstable feature is large or has a lot of design space to explore then you might want to block merging it on a RFC.
+New unstable features don’t need an RFC before they can be merged. They do need one before they can be stabilized. New impls for already stable traits don't need an RFC. If a new unstable feature is large or has a lot of design space to explore then you might want to block merging it on an RFC.
 
 ### Is there any `unsafe`?
 

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -144,7 +144,7 @@ This kind of breakage can be ok, but a [`crater`] run should estimate the scope.
 
 ### Could an implementation use existing functionality?
 
-Types like `String` are implemented in terms of `Vec<u8>` and can use methods on `str` through deref coersion. `Vec<T>` can use methods on `[T]` through deref coersion. When possible, methods on a wrapping type like `String` should defer to methods that already exis on their underlying storage or deref target.
+Types like `String` are implemented in terms of `Vec<u8>` and can use methods on `str` through deref coersion. `Vec<T>` can use methods on `[T]` through deref coersion. When possible, methods on a wrapping type like `String` should defer to methods that already exist on their underlying storage or deref target.
 
 ### Are there `#[fundamental]` items involved?
 


### PR DESCRIPTION
Recently in Libs we've been talking about putting together some docs with various things we try to keep in mind when working on `std` (inspired by [.NET's runtime developer guide](https://github.com/dotnet/coreclr/blob/master/Documentation/coding-guidelines/clr-code-guide.md)), and we thought the forge here would be a good home.

This PR is an attempt to bootstrap that doc. There's not a lot here yet, and what is there is probably both incomplete and plain incorrect :) It's just a starting point to iterate on, so any suggested corrections/enhancements would be greatly appreciated! Any thoughts on organization would also be good.

cc @rust-lang/libs 

[Rendered](https://github.com/KodrAus/rust-forge/blob/libs/src/libs/maintaining-std.md)