### PR TITLE
platform-support: tick aarch64-unknown-freebsd

### DIFF
--- a/src/release/platform-support.md
+++ b/src/release/platform-support.md
@@ -141,7 +141,7 @@ not available.
 
 target | std | rustc | cargo | notes
 -------|-----|-------|-------|-------
-`aarch64-unknown-freebsd` | ? |  |  |
+`aarch64-unknown-freebsd` | ✓ | ✓ | ✓ | ARM64 FreeBSD
 `aarch64-unknown-hermit` | ? |  |  |
 `aarch64-unknown-netbsd` | ? |  |  |
 `aarch64-unknown-none` | ? |  |  |


### PR DESCRIPTION
- a required [TLS fix](https://reviews.freebsd.org/rS342113) has landed a year ago
- it has been available in FreeBSD packages for a while
- [recent build log example](http://thunderx1.nyi.freebsd.org/data/head-arm64-default/p518178_s355024/logs/rust-1.39.0.log)
