### PR TITLE
Remove duplicated line in platform list

### DIFF
--- a/src/release/platform-support.md
+++ b/src/release/platform-support.md
@@ -173,7 +173,6 @@ target | std | rustc | cargo | notes
 `mipsisa64r6el-unknown-linux-gnuabi64` | ? |  |  |
 `msp430-none-elf` | * |  |  | 16-bit MSP430 microcontrollers
 `nvptx64-nvidia-cuda` | ** |  |  | --emit=asm generates PTX code that [runs on NVIDIA GPUs]
-`nvptx64-nvidia-cuda` | ** |  |  | --emit=asm generates PTX code that [runs on NVIDIA GPUs]
 `powerpc-unknown-linux-musl` | ? |  |  |
 `powerpc-unknown-netbsd` | ? |  |  |
 `powerpc-wrs-vxworks` | ? |  |  |


### PR DESCRIPTION
This patch remove duplicated `nvptx64-nvidia-cuda` line in https://forge.rust-lang.org/release/platform-support.html