### PR TITLE
blacksmith: cache the manifests and targets for an hour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 book
+.blacksmith-cache.json


### PR DESCRIPTION
Before this PR, the preprocessor fetched the channel manifests to figure out the stable version and the available targets every single build. This was annoying especially when running `mdbook serve`, which rebuilds the content automatically every time a file changes on disk.

This PR caches that information in an ignored .blacksmith-cache.json file, with a TTL of an hour. Within the hour the old data will be reused, and after that amount of time new data will be fetched to refresh the cache.

This shouldn't affect CI or other production builds, as the repository as a whole isn't cached between builds.

r? @XAMPPRocky 