### PR TITLE
Allow setting CARGO_TARGET_DIR

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
-(cd blacksmith && cargo build)
+set -euo pipefail
 
-./blacksmith/target/debug/mdbook-blacksmith "$@"
+TARGET=${CARGO_TARGET_DIR:-target}
+# https://stackoverflow.com/a/3572105
+realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+cd blacksmith
+cargo build
+BLACKSMITH="$(realpath "$TARGET/debug/mdbook-blacksmith")"
+cd "$OLDPWD"
+"$BLACKSMITH" "$@"


### PR DESCRIPTION
This ended up being a little more complicated than I wanted because it
allows for CARGO_TARGET_DIR to be both a relative and absolute path. It
should work anywhere with bash installed.