### PR TITLE
Stabilizing const functions

### DIFF
--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -197,10 +197,6 @@ Changes to hot code might impact performance in consumers, for better or for wor
 
 PRs shouldn’t have merge commits in them. If they become out of date with `master` then they need to be rebased.
 
-### Are functions const-stabilized or constified?
-
-Please CC `@rust-lang/wg-const-eval`.
-
 ## Merging PRs
 
 PRs to [`rust-lang/rust`] aren’t merged manually using GitHub’s UI or by pushing remote branches. Everything goes through [`bors`].
@@ -229,7 +225,11 @@ You can find the right version to use in the `#[stable]` attribute by checking t
 
 ### When a `const` function is being stabilized
 
-Const functions can be stabilized in a PR that replaces `#[rustc_const_unstable]` attributes with `#[rustc_const_stable]` ones. The [Constant Evaluation WG] should be pinged for input on whether or not the `const`-ness is something we want to commit to. This is particularly important when the function internally depends on other unstable `const` functions through `#[allow_internal_unstable]` attributes.
+Const functions can be stabilized in a PR that replaces `#[rustc_const_unstable]` attributes with `#[rustc_const_stable]` ones. The [Constant Evaluation WG] should be pinged for input on whether or not the `const`-ness is something we want to commit to. If it is an intrinsic being exposed that is const-stabilized then `@rust-lang/lang` should also be included in the FCP.
+
+Check whether the function internally depends on other unstable `const` functions through `#[allow_internal_unstable]` attributes and consider how the function could be implemented if its internally unstable calls were removed. See the _Stability attributes_ page for more details on `#[allow_internal_unstable]`.
+
+Where `unsafe` and `const` is involved, e.g., for operations which are "unconst", that the const safety argument for the usage also be documented. That is, a `const fn` has additional determinism (e.g. run-time/compile-time results must correspond and the function's output only depends on its inputs...) restrictions that must be preserved, and those should be argued when `unsafe` is used.
 
 [API Guidelines]: https://rust-lang.github.io/api-guidelines
 [Unsafe Code Guidelines WG]: https://github.com/rust-lang/unsafe-code-guidelines

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -227,8 +227,13 @@ Features can be stabilized in a PR that replaces `#[unstable]` attributes with `
 
 You can find the right version to use in the `#[stable]` attribute by checking the [Forge].
 
+### When a `const` function is being stabilized
+
+Const functions can be stabilized in a PR that replaced `#[rustc_const_unstable]` attributes with `#[rustc_const_stable]` ones. The [Constant Evaluation WG] should be pinged for input on whether or not the `const`-ness is something we want to commit to.
+
 [API Guidelines]: https://rust-lang.github.io/api-guidelines
 [Unsafe Code Guidelines WG]: https://github.com/rust-lang/unsafe-code-guidelines
+[Constant Evaluation WG]: https://github.com/rust-lang/const-eval
 [`rust-lang/rust`]: https://github.com/rust-lang/rust
 [`rust-lang/rfcs`]: https://github.com/rust-lang/rfcs
 [`rust-lang/rust-forge`]: https://github.com/rust-lang/rust-forge

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -229,7 +229,7 @@ You can find the right version to use in the `#[stable]` attribute by checking t
 
 ### When a `const` function is being stabilized
 
-Const functions can be stabilized in a PR that replaced `#[rustc_const_unstable]` attributes with `#[rustc_const_stable]` ones. The [Constant Evaluation WG] should be pinged for input on whether or not the `const`-ness is something we want to commit to.
+Const functions can be stabilized in a PR that replaces `#[rustc_const_unstable]` attributes with `#[rustc_const_stable]` ones. The [Constant Evaluation WG] should be pinged for input on whether or not the `const`-ness is something we want to commit to. This is particularly important when the function internally depends on other unstable `const` functions through `#[allow_internal_unstable]` attributes.
 
 [API Guidelines]: https://rust-lang.github.io/api-guidelines
 [Unsafe Code Guidelines WG]: https://github.com/rust-lang/unsafe-code-guidelines


### PR DESCRIPTION
cc @rust-lang/libs @rust-lang/wg-const-eval 

In https://github.com/rust-lang/rust/pull/69373#issuecomment-591041786 it was noted that stabilizing the `const`-ness of functions should include the WG. Should this only really be necessary when there are internal unstable const features used in those stabilizing functions?

@ecstatic-morse offered [some guidelines](https://github.com/rust-lang/rust/pull/69373#issuecomment-591070340) on things to keep in mind when stabilizing `const` functions with internally unstable features. Would you like that to be included here?