### PR TITLE
Update rustc-guide to rustc-dev-guide

### DIFF
--- a/blacksmith/src/lib.rs
+++ b/blacksmith/src/lib.rs
@@ -140,10 +140,10 @@ impl Blacksmith {
         #[rustfmt::skip]
         const REDIRECTS: &[(&str, &str)] = &[
             ("beta-backporting.html", "/release/beta-backporting.html"),
-            ("bibliography.html", "https://rust-lang.github.io/rustc-dev-guide/appendix/bibliography.html"),
+            ("bibliography.html", "https://rustc-dev-guide.rust-lang.org/appendix/bibliography.html"),
             ("channel-layout.html", "/infra/channel-layout.html"),
-            ("debugging.html", "https://rust-lang.github.io/rustc-dev-guide/compiler-debugging.html"),
-            ("feature_guide.html", "https://rust-lang.github.io/rustc-dev-guide/implementing_new_features.html"),
+            ("debugging.html", "https://rustc-dev-guide.rust-lang.org/compiler-debugging.html"),
+            ("feature_guide.html", "https://rustc-dev-guide.rust-lang.org/implementing_new_features.html"),
             ("fott.html", "/archive/fott.html"),
             ("infrastructure.html", "/infra/service-infrastructure.html"),
             ("other-installation-methods.html", "/infra/other-installation-methods.html"),
@@ -155,15 +155,15 @@ impl Blacksmith {
             ("rustc-bug-fix-procedure.html", "/compiler/bug-fix-procedure.html"),
             ("rustc-diagnostic-code.html", "/compiler/diagnostic-codes.html"),
             ("rustc-team-maintenance.html", "/infra/team-maintenance.html"),
-            ("stabilization-guide.html", "https://rust-lang.github.io/rustc-dev-guide/stabilization_guide.html"),
+            ("stabilization-guide.html", "https://rustc-dev-guide.rust-lang.org/stabilization_guide.html"),
             ("state-of-rust.html", "https://github.com/rust-lang/rust/projects/8"),
-            ("test-suite.html", "https://rust-lang.github.io/rustc-dev-guide/tests/intro.html"),
+            ("test-suite.html", "https://rustc-dev-guide.rust-lang.org/tests/intro.html"),
             ("toolstate.html", "/infra/toolstate.html"),
             ("triage-procedure.html", "/release/triage-procedure.html"),
-            ("x-py.html", "https://rust-lang.github.io/rustc-dev-guide/building/how-to-build-and-run.html"),
-            ("compiler/bug-fix-procedure.html", "https://rust-lang.github.io/rustc-dev-guide/bug-fix-procedure.html"),
-            ("compiler/diagnostic-codes.html", "https://rust-lang.github.io/rustc-dev-guide/diagnostics/diagnostic-codes.html"),
-            ("compiler/profile-queries.html", "https://rust-lang.github.io/rustc-dev-guide/queries/profiling.html"),
+            ("x-py.html", "https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html"),
+            ("compiler/bug-fix-procedure.html", "https://rustc-dev-guide.rust-lang.org/bug-fix-procedure.html"),
+            ("compiler/diagnostic-codes.html", "https://rustc-dev-guide.rust-lang.org/diagnostics/diagnostic-codes.html"),
+            ("compiler/profile-queries.html", "https://rustc-dev-guide.rust-lang.org/queries/profiling.html"),
         ];
 
         // Inititalise book directory if not built yet.

--- a/blacksmith/src/lib.rs
+++ b/blacksmith/src/lib.rs
@@ -140,10 +140,10 @@ impl Blacksmith {
         #[rustfmt::skip]
         const REDIRECTS: &[(&str, &str)] = &[
             ("beta-backporting.html", "/release/beta-backporting.html"),
-            ("bibliography.html", "https://rust-lang.github.io/rustc-guide/appendix/bibliography.html"),
+            ("bibliography.html", "https://rust-lang.github.io/rustc-dev-guide/appendix/bibliography.html"),
             ("channel-layout.html", "/infra/channel-layout.html"),
-            ("debugging.html", "https://rust-lang.github.io/rustc-guide/compiler-debugging.html"),
-            ("feature_guide.html", "https://rust-lang.github.io/rustc-guide/implementing_new_features.html"),
+            ("debugging.html", "https://rust-lang.github.io/rustc-dev-guide/compiler-debugging.html"),
+            ("feature_guide.html", "https://rust-lang.github.io/rustc-dev-guide/implementing_new_features.html"),
             ("fott.html", "/archive/fott.html"),
             ("infrastructure.html", "/infra/service-infrastructure.html"),
             ("other-installation-methods.html", "/infra/other-installation-methods.html"),
@@ -155,15 +155,15 @@ impl Blacksmith {
             ("rustc-bug-fix-procedure.html", "/compiler/bug-fix-procedure.html"),
             ("rustc-diagnostic-code.html", "/compiler/diagnostic-codes.html"),
             ("rustc-team-maintenance.html", "/infra/team-maintenance.html"),
-            ("stabilization-guide.html", "https://rust-lang.github.io/rustc-guide/stabilization_guide.html"),
+            ("stabilization-guide.html", "https://rust-lang.github.io/rustc-dev-guide/stabilization_guide.html"),
             ("state-of-rust.html", "https://github.com/rust-lang/rust/projects/8"),
-            ("test-suite.html", "https://rust-lang.github.io/rustc-guide/tests/intro.html"),
+            ("test-suite.html", "https://rust-lang.github.io/rustc-dev-guide/tests/intro.html"),
             ("toolstate.html", "/infra/toolstate.html"),
             ("triage-procedure.html", "/release/triage-procedure.html"),
-            ("x-py.html", "https://rust-lang.github.io/rustc-guide/building/how-to-build-and-run.html"),
-            ("compiler/bug-fix-procedure.html", "https://rust-lang.github.io/rustc-guide/bug-fix-procedure.html"),
-            ("compiler/diagnostic-codes.html", "https://rust-lang.github.io/rustc-guide/diagnostics/diagnostic-codes.html"),
-            ("compiler/profile-queries.html", "https://rust-lang.github.io/rustc-guide/queries/profiling.html"),
+            ("x-py.html", "https://rust-lang.github.io/rustc-dev-guide/building/how-to-build-and-run.html"),
+            ("compiler/bug-fix-procedure.html", "https://rust-lang.github.io/rustc-dev-guide/bug-fix-procedure.html"),
+            ("compiler/diagnostic-codes.html", "https://rust-lang.github.io/rustc-dev-guide/diagnostics/diagnostic-codes.html"),
+            ("compiler/profile-queries.html", "https://rust-lang.github.io/rustc-dev-guide/queries/profiling.html"),
         ];
 
         // Inititalise book directory if not built yet.

--- a/src/README.md
+++ b/src/README.md
@@ -41,5 +41,5 @@ Nightly | <span id="nightly-cycle"></span> | <span id="nightly-timespan"></span>
 * [Rust Pontoon] is a translation management system used to localize the Rust
   website.
 
-[Bibliography]: https://rust-lang.github.io/rustc-dev-guide/appendix/bibliography.html
+[Bibliography]: https://rustc-dev-guide.rust-lang.org/appendix/bibliography.html
 [Rust Pontoon]: https://pontoon.rust-lang.org/

--- a/src/README.md
+++ b/src/README.md
@@ -41,5 +41,5 @@ Nightly | <span id="nightly-cycle"></span> | <span id="nightly-timespan"></span>
 * [Rust Pontoon] is a translation management system used to localize the Rust
   website.
 
-[Bibliography]: https://rust-lang.github.io/rustc-guide/appendix/bibliography.html
+[Bibliography]: https://rust-lang.github.io/rustc-dev-guide/appendix/bibliography.html
 [Rust Pontoon]: https://pontoon.rust-lang.org/

--- a/src/chat/zulip.md
+++ b/src/chat/zulip.md
@@ -177,7 +177,7 @@ We currently support linking to issues on a few repositories:
 * rust-lang/miri with `miri#3434`
 * rust-lang-nursery/polonius with `polonius#3434`
 * rust-analyzer/rust-analyzer with `rust-analyzer#3434`
-* rust-lang/rustc-guide with `rustc-guide#3434`
+* rust-lang/rustc-dev-guide with `rustc-dev-guide#3434`
 * rust-lang/stdarch with `stdarch#3434`
 * rust-lang/team with `team#3434`
 * rust-lang/unsafe-code-guidelines with `ucg#3434`

--- a/src/compiler/README.md
+++ b/src/compiler/README.md
@@ -3,7 +3,7 @@ This section documents the Rust compiler itself, its APIs, and how to
 contribute and provide bug fixes for the compiler.
 
 ### External Links
-* The [Rustc guide] documents how the compiler works as well providing helpful
+* The [Rustc Dev Guide] documents how the compiler works as well providing helpful
   information to help get new contributors involved in the development.
 * Rustc's [internal documentation].
 * The [Compiler team] website is the home for all of the compiler
@@ -13,5 +13,5 @@ contribute and provide bug fixes for the compiler.
 
 [Compiler team]: https://rust-lang.github.io/compiler-team/
 [FIXME page]: https://oli-obk.github.io/fixmeh/
-[Rustc guide]: https://rust-lang.github.io/rustc-guide/
+[Rustc Dev Guide]: https://rust-lang.github.io/rustc-dev-guide/
 [internal documentation]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/

--- a/src/compiler/README.md
+++ b/src/compiler/README.md
@@ -13,5 +13,5 @@ contribute and provide bug fixes for the compiler.
 
 [Compiler team]: https://rust-lang.github.io/compiler-team/
 [FIXME page]: https://oli-obk.github.io/fixmeh/
-[Rustc Dev Guide]: https://rust-lang.github.io/rustc-dev-guide/
+[Rustc Dev Guide]: https://rustc-dev-guide.rust-lang.org/
 [internal documentation]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/

--- a/src/infra/toolstate.md
+++ b/src/infra/toolstate.md
@@ -31,7 +31,7 @@ rules are for when which tools are (not) allowed to break.
       cut. (See the [Forge index][forge] for when the next beta cutoff is
       happening.)
 
-    At the time of writing, the following tools are "nightly only": rustc-guide,
+    At the time of writing, the following tools are "nightly only": rustc-dev-guide,
     miri, embedded-book.
 
 ## Updating the toolstate repository

--- a/src/lang/rfc-merge-procedure.md
+++ b/src/lang/rfc-merge-procedure.md
@@ -19,11 +19,11 @@ This is a tracking issue for the RFC "XXX" (rust-lang/rfcs#NNN).
 
 - [ ] Implement the RFC (cc @rust-lang/XXX -- can anyone write up mentoring
       instructions?)
-- [ ] Adjust documentation ([see instructions on rustc-guide][doc-guide])
-- [ ] Stabilization PR ([see instructions on rustc-guide][stabilization-guide])
+- [ ] Adjust documentation ([see instructions on rustc-dev-guide][doc-guide])
+- [ ] Stabilization PR ([see instructions on rustc-dev-guide][stabilization-guide])
 
-[stabilization-guide]: https://rust-lang.github.io/rustc-guide/stabilization_guide.html#stabilization-pr
-[doc-guide]: https://rust-lang.github.io/rustc-guide/stabilization_guide.html#documentation-prs
+[stabilization-guide]: https://rust-lang.github.io/rustc-dev-guide/stabilization_guide.html#stabilization-pr
+[doc-guide]: https://rust-lang.github.io/rustc-dev-guide/stabilization_guide.html#documentation-prs
 
 **Unresolved questions:**
 

--- a/src/lang/rfc-merge-procedure.md
+++ b/src/lang/rfc-merge-procedure.md
@@ -22,8 +22,8 @@ This is a tracking issue for the RFC "XXX" (rust-lang/rfcs#NNN).
 - [ ] Adjust documentation ([see instructions on rustc-dev-guide][doc-guide])
 - [ ] Stabilization PR ([see instructions on rustc-dev-guide][stabilization-guide])
 
-[stabilization-guide]: https://rust-lang.github.io/rustc-dev-guide/stabilization_guide.html#stabilization-pr
-[doc-guide]: https://rust-lang.github.io/rustc-dev-guide/stabilization_guide.html#documentation-prs
+[stabilization-guide]: https://rustc-dev-guide.rust-lang.org/stabilization_guide.html#stabilization-pr
+[doc-guide]: https://rustc-dev-guide.rust-lang.org/stabilization_guide.html#documentation-prs
 
 **Unresolved questions:**
 


### PR DESCRIPTION
The rustc-guide is being renamed to the rustc-dev-guide. The discussion is in rust-lang/rustc-guide#470.

This PR revises rustc-guide to rustc-dev-guide in the `blacksmithc/src/lib.rs` and the Markdown files.

Transition tracker: rust-lang/rustc-guide#602