### PR TITLE
Add note about CCing `@rust-lang/wg-const-eval` for const fn PRs

### DIFF
--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -197,6 +197,10 @@ Changes to hot code might impact performance in consumers, for better or for wor
 
 PRs shouldn’t have merge commits in them. If they become out of date with `master` then they need to be rebased.
 
+### Are functions const-stabilized or constified?
+
+Please CC `@rust-lang/wg-const-eval`.
+
 ## Merging PRs
 
 PRs to [`rust-lang/rust`] aren’t merged manually using GitHub’s UI or by pushing remote branches. Everything goes through [`bors`].


### PR DESCRIPTION
I was made aware of this [here](https://github.com/rust-lang/rust/pull/69617#issuecomment-599434746). I guess this note is useful in this document.