### PR TITLE
Add Help Wanted section to index.

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -7,14 +7,6 @@ file an issue or PR on the [Rust Forge GitHub].
 [The Rust Programming Language]: https://rust-lang.org
 [Rust Forge GitHub]: https://github.com/rust-lang/rust-forge
 
-<!-- All `<span id="..."></span>` elements are filled at run time when a reader
-visits the website. Please refer to `js/index.js` for how these values
-are generated.
-
-Avoid changing the "Current Release Versions" without also updating the selector
-in `js/index.js`.
--->
-
 ### Help Wanted
 
 Want to contribute to Rust, but don't know where to start? Here's a list of 
@@ -34,6 +26,14 @@ Repository                  | Description
 [gh/www]: https://github.com/rust-lang/www.rust-lang.org/labels/good%20first%20issue
 
 ### Current Release Versions
+
+<!-- All `<span id="..."></span>` elements are filled at run time when a reader
+visits the website. Please refer to `js/index.js` for how these values
+are generated.
+
+Avoid changing the "Current Release Versions" without also updating the selector
+in `js/index.js`.
+-->
 
 Channel    | Version | Release Date
 -----------|---------|-------------

--- a/src/README.md
+++ b/src/README.md
@@ -12,8 +12,26 @@ visits the website. Please refer to `js/index.js` for how these values
 are generated.
 
 Avoid changing the "Current Release Versions" without also updating the selector
-in `js/index.js.
+in `js/index.js`.
 -->
+
+### Help Wanted
+
+Want to contribute to Rust, but don't know where to start? Here's a list of 
+`rust-lang` projects that have marked issues that need help and issues that are
+good first issues.
+
+Repository                  | Description
+----------------------------|-----------------------------------------------
+[rust][gh/rust]             | The Rust Language & Compiler
+[cargo][gh/cargo]           | The Rust package manager
+[crates.io][gh/crates.io]   | Source code for [crates.io](https://crates.io)
+[www.rust-lang.org][gh/www] | The Rust website
+
+[gh/rust]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-help-wanted
+[gh/cargo]: https://github.com/rust-lang/crates.io/issues?q=is%3Aopen+is%3Aissue+label%3AE-help-wanted
+[gh/crates.io]: https://github.com/rust-lang/crates.io/issues?q=is%3Aopen+is%3Aissue+label%3AE-help-wanted
+[gh/www]: https://github.com/rust-lang/www.rust-lang.org/labels/good%20first%20issue
 
 ### Current Release Versions
 

--- a/src/README.md
+++ b/src/README.md
@@ -29,7 +29,7 @@ Repository                  | Description
 [www.rust-lang.org][gh/www] | The Rust website
 
 [gh/rust]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-help-wanted
-[gh/cargo]: https://github.com/rust-lang/crates.io/issues?q=is%3Aopen+is%3Aissue+label%3AE-help-wanted
+[gh/cargo]: https://github.com/rust-lang/cargo/issues?q=is%3Aopen+is%3Aissue+label%3AE-help-wanted
 [gh/crates.io]: https://github.com/rust-lang/crates.io/issues?q=is%3Aopen+is%3Aissue+label%3AE-help-wanted
 [gh/www]: https://github.com/rust-lang/www.rust-lang.org/labels/good%20first%20issue
 


### PR DESCRIPTION
Adds a section providing links to each repositories list of issues that are marked as need help and/or good first issue. I started with this small list, but we can also add other projects.