### PR TITLE
Update team maintenance.

### DIFF
--- a/src/infra/team-maintenance.md
+++ b/src/infra/team-maintenance.md
@@ -6,32 +6,35 @@ they are not currently an active part of the decision-making process.
 Unfortunately, whenever a new person is added or someone goes into alumni
 status, there are a number of disparate places that need to be updated. This
 page aims to document that list. If you have any questions, or need someone with
-more privileges to make a change for you, a good place to ask is #rust-infra (or
-possibly #rust-internals).
+more privileges to make a change for you, a good place to ask is `#infra` on
+Discord.
 
-### R+ rights
+### Team repo
 
-If just giving r+ rights, the following places need to be modified:
+Membership of teams is primarily driven by the config files in the
+[rust-lang/team repo][team repo]. Several systems use the team repo data to
+control access:
 
-- the [homu template on rust-central-station][homu]
+- the [team website]
+- bors r+ rights
+- rfcbot interaction
+
+Team membership is duplicated in a few other places listed below, but the
+long-term goal is to centralize on the team repo.
 
 ### Full team membership
 
 To make a full team member, the following places need to be modified:
 
-- the [team roster page][team-roster]
+- the [team repo]
 - the [rust-lang/TEAM][gh-team] and (in some cases)
   [rust-lang-nursery/TEAM][gh-nursery-team] teams on github must be updated
-- rfcbot has a separate list of people on a team that is maintained in a
-  configuration file
-  - [here is an example commit that was adding Centril to the lang
-    team][rfcbot-example]
 - the easydns service has an e-mail alias (`compiler-team@rust-lang.org`) that
   needs to be updated
-  - best here is to ask around in #rust-infra
+  - best here is to ask around in #infra
 - the
   [internals discussion board has per-team groups](https://internals.rust-lang.org/admin/groups/custom)
-- the list of reviewers highfive uses is set in [nrc/highfive][highfive]
+- the list of reviewers highfive uses is set in [rust-lang/highfive][highfive]
   - the configs are set per-repo; some teams are listed in `rust.json`, whereas
     those that span multiple repos are set in `_global.json`
 
@@ -39,17 +42,14 @@ To make a full team member, the following places need to be modified:
 
 Remove the team member from any and all places:
 
-- [highfive][]
-- [reviewers list][homu]
-- rfcbot ([example][rfcbot-example])
+- [highfive]
 - 1password
 - The [GitHub team][gh-team], [GitHub nursery team][gh-nursery-team]
 - email aliases (as above)
-- [team roster page][team-roster]
+- [team repo]
 
-[homu]: https://github.com/alexcrichton/rust-central-station/blob/master/homu.toml.template
-[team-roster]: https://github.com/rust-lang/rust-www/blob/master/_data/team.yml
 [gh-team]: https://github.com/orgs/rust-lang/teams
 [gh-nursery-team]: https://github.com/orgs/rust-lang-nursery/teams
-[highfive]: https://github.com/nrc/highfive/tree/master/highfive/configs
-[rfcbot-example]: https://github.com/anp/rfcbot-rs/commit/cd54241359cf65742ed5a0fba58ea5114de06f2b#diff-100115fcbdda685c37ba8f73727b0987
+[highfive]: https://github.com/rust-lang/highfive/tree/master/highfive/configs
+[team repo]: https://github.com/rust-lang/team/tree/master/teams
+[team website]: https://www.rust-lang.org/governance

--- a/src/infra/team-maintenance.md
+++ b/src/infra/team-maintenance.md
@@ -18,6 +18,7 @@ control access:
 - the [team website]
 - bors r+ rights
 - rfcbot interaction
+- Mailgun email lists
 
 Team membership is duplicated in a few other places listed below, but the
 long-term goal is to centralize on the team repo.
@@ -29,9 +30,6 @@ To make a full team member, the following places need to be modified:
 - the [team repo]
 - the [rust-lang/TEAM][gh-team] and (in some cases)
   [rust-lang-nursery/TEAM][gh-nursery-team] teams on github must be updated
-- the easydns service has an e-mail alias (`compiler-team@rust-lang.org`) that
-  needs to be updated
-  - best here is to ask around in #infra
 - the
   [internals discussion board has per-team groups](https://internals.rust-lang.org/admin/groups/custom)
 - the list of reviewers highfive uses is set in [rust-lang/highfive][highfive]
@@ -45,11 +43,12 @@ Remove the team member from any and all places:
 - [highfive]
 - 1password
 - The [GitHub team][gh-team], [GitHub nursery team][gh-nursery-team]
-- email aliases (as above)
 - [team repo]
+- [toolstate notifications]
 
 [gh-team]: https://github.com/orgs/rust-lang/teams
 [gh-nursery-team]: https://github.com/orgs/rust-lang-nursery/teams
 [highfive]: https://github.com/rust-lang/highfive/tree/master/highfive/configs
 [team repo]: https://github.com/rust-lang/team/tree/master/teams
 [team website]: https://www.rust-lang.org/governance
+[toolstate notifications]: https://github.com/rust-lang/rust/blob/master/src/tools/publish_toolstate.py


### PR DESCRIPTION
Updates a few things that I'm aware of:

- the website team roster is now driven by the team repo
- rfcbot is now driven by the team repo
- bors is now driven by the team repo
- highfive repo has moved
