### PR TITLE
platform-support: add tier3 riscv64gc-unknown-linux-gnu

### DIFF
--- a/src/release/platform-support.md
+++ b/src/release/platform-support.md
@@ -184,6 +184,7 @@ target | std | rustc | cargo | notes
 `powerpc64-wrs-vxworks` | ? |  |  |
 `powerpc64le-unknown-linux-musl` | ? |  |  |
 `riscv32i-unknown-none-elf` | ? |  |  |
+`riscv64gc-unknown-linux-gnu` | ✓ | ✓ | ✓ |
 `sparc64-unknown-netbsd` | ✓ | ✓ |  | NetBSD/sparc64
 `sparc64-unknown-openbsd` | ? |  |  |
 `thumbv7a-pc-windows-msvc` | ? |  |  |


### PR DESCRIPTION
Compiler support was merged [here](https://github.com/rust-lang/rust/pull/66661).

There is an issue tracking this support [here](https://github.com/rust-lang/rust/issues/62117).

Stable is already built with `riscv64gc-unknown-linux-gnu` target support. To try it see [my PR adding support to cross](https://github.com/rust-embedded/cross/pull/413).