### PR TITLE
Update platform tiers.

### DIFF
--- a/src/release/platform-support.md
+++ b/src/release/platform-support.md
@@ -48,6 +48,8 @@ target | std | rustc | cargo | notes
 `aarch64-pc-windows-msvc` | ✓ |  |  | ARM64 Windows MSVC
 `aarch64-unknown-linux-gnu` | ✓ | ✓ | ✓ | ARM64 Linux
 `aarch64-unknown-linux-musl` | ✓ |  |  | ARM64 Linux with MUSL
+`aarch64-unknown-none` | * |  |  | Bare ARM64, hardfloat
+`aarch64-unknown-none-softfloat` | * |  |  | Bare ARM64, softfloat
 `arm-linux-androideabi` | ✓ |  |  | ARMv7 Android
 `arm-unknown-linux-gnueabi` | ✓ | ✓ | ✓ | ARMv6 Linux
 `arm-unknown-linux-gnueabihf` | ✓ | ✓ | ✓ | ARMv6 Linux, hardfloat
@@ -61,7 +63,9 @@ target | std | rustc | cargo | notes
 `armv7a-none-eabi` | * |  |  | Bare ARMv7-A
 `armv7r-none-eabi` | * |  |  | Bare ARMv7-R
 `armv7r-none-eabihf` | * |  |  | Bare ARMv7-R, hardfloat
-`armv7-unknown-linux-gnueabihf` | ✓ | ✓ | ✓ | ARMv7 Linux
+`armv7-unknown-linux-gnueabi` | ✓ |   |   | ARMv7 Linux, glibc
+`armv7-unknown-linux-gnueabihf` | ✓ | ✓ | ✓ | ARMv7 Linux, hardfloat
+`armv7-unknown-linux-musleabi` | ✓ |   |   | ARMv7 Linux, MUSL
 `armv7-unknown-linux-musleabihf` | ✓ |  |  | ARMv7 Linux with MUSL
 `asmjs-unknown-emscripten` | ✓ |  |  | asm.js via Emscripten
 `i586-pc-windows-msvc` | ✓ |  |  | 32-bit Windows w/o SSE
@@ -139,10 +143,10 @@ not available.
 
 target | std | rustc | cargo | notes
 -------|-----|-------|-------|-------
+`aarch64-apple-tvos` | ** |  |  | ARM64 tvOS
 `aarch64-unknown-freebsd` | ✓ | ✓ | ✓ | ARM64 FreeBSD
 `aarch64-unknown-hermit` | ? |  |  |
 `aarch64-unknown-netbsd` | ? |  |  |
-`aarch64-unknown-none` | ? |  |  |
 `aarch64-unknown-openbsd` | ✓ | ✓ | ✓ | ARM64 OpenBSD
 `aarch64-unknown-redox` | ? |  |  |
 `aarch64-uwp-windows-msvc` | ? |  |  |
@@ -154,11 +158,13 @@ target | std | rustc | cargo | notes
 `armv7-unknown-freebsd` | ✓ | ✓ | ✓ | ARMv7 FreeBSD
 `armv7-unknown-netbsd-eabihf` | ? |  |  |
 `armv7-wrs-vxworks-eabihf` | ? |  |  |
+`armv7a-none-eabihf` | * | | | ARM Cortex-A, hardfloat
 `armv7s-apple-ios` | ✓ |  |  |
 `hexagon-unknown-linux-musl` | ? |  |  |
 `i386-apple-ios` | ✓ |  |  | 32-bit x86 iOS
 `i686-apple-darwin` | ✓ | ✓ | ✓ | 32-bit OSX (10.7+, Lion+)
 `i686-pc-windows-msvc` | ✓ |  |  | 32-bit Windows XP support
+`i686-unknown-uefi` | ? |  |  | 32-bit UEFI
 `i686-unknown-haiku` | ✓ | ✓ | ✓ | 32-bit Haiku
 `i686-unknown-netbsd` | ✓ |  |  | NetBSD/i386 with SSE2
 `i686-unknown-openbsd` | ✓ | ✓ | ✓ | 32-bit OpenBSD
@@ -174,7 +180,7 @@ target | std | rustc | cargo | notes
 `mipsisa64r6-unknown-linux-gnuabi64` | ? |  |  |
 `mipsisa64r6el-unknown-linux-gnuabi64` | ? |  |  |
 `msp430-none-elf` | * |  |  | 16-bit MSP430 microcontrollers
-`nvptx64-nvidia-cuda` | ** |  |  | --emit=asm generates PTX code that [runs on NVIDIA GPUs]
+`nvptx64-nvidia-cuda` | ✓ |  |  | --emit=asm generates PTX code that [runs on NVIDIA GPUs]
 `powerpc-unknown-linux-musl` | ? |  |  |
 `powerpc-unknown-netbsd` | ? |  |  |
 `powerpc-wrs-vxworks` | ? |  |  |
@@ -188,14 +194,20 @@ target | std | rustc | cargo | notes
 `sparc64-unknown-netbsd` | ✓ | ✓ |  | NetBSD/sparc64
 `sparc64-unknown-openbsd` | ? |  |  |
 `thumbv7a-pc-windows-msvc` | ? |  |  |
+`thumbv7neon-unknown-linux-musleabihf` | ? |  |  | Thumb2-mode ARMv7a Linux with NEON, MUSL
 `thumbv8m.base-none-eabi` | ? |  |  |
 `thumbv8m.main-none-eabi` | ? |  |  |
 `thumbv8m.main-none-eabihf` | ? |  |  |
+`x86_64-apple-ios-macabi` | ✓ |  |  | Apple Catalyst
+`x86_64-apple-tvos` | ** | | | x86 64-bit tvOS
+`x86_64-linux-kernel` | ? |  |  | Linux kernel modules
 `x86_64-pc-solaris` | ? |  |  |
 `x86_64-pc-windows-msvc` | ✓ |  |  | 64-bit Windows XP support
 `x86_64-unknown-dragonfly` | ✓ | ✓ | ✓ | 64-bit DragonFlyBSD
 `x86_64-unknown-haiku` | ✓ | ✓ | ✓ | 64-bit Haiku
 `x86_64-unknown-hermit` | ? |  |  |
+`x86_64-unknown-hermit-kernel` | ? |  |  | HermitCore kernel
+`x86_64-unknown-illumos` | ✓ |  |  | illumos
 `x86_64-unknown-l4re-uclibc` | ? |  |  |
 `x86_64-unknown-openbsd` | ✓ | ✓ | ✓ | 64-bit OpenBSD
 `x86_64-unknown-uefi` | ? |  |  |
@@ -205,12 +217,9 @@ target | std | rustc | cargo | notes
 
 [runs on NVIDIA GPUs]: https://github.com/japaric-archived/nvptx#targets
 
-\* These are bare-metal microcontroller targets that only have access to the
-   core library, not std.
+\* These targets only support `core`, not `alloc` or `std`.
 
-\*\* There’s backend support for these targets but no target built into rustc
-     (yet). You’ll have to write your own target specification file (see the
-     links in the table). These targets only support the core library.
+\*\* These targets only support `core` or `alloc`, not `std`.
 
 ? These are targets that haven't yet been documented here. If you can shed some
   light on these platforms support, please create an issue or PR on the [Rust

--- a/src/release/platform-support.md
+++ b/src/release/platform-support.md
@@ -194,7 +194,6 @@ target | std | rustc | cargo | notes
 `wasm32-experimental-emscripten` | ? |  |  |
 `x86_64-pc-solaris` | ? |  |  |
 `x86_64-pc-windows-msvc` | ✓ |  |  | 64-bit Windows XP support
-`x86_64-unknown-bitrig` | ✓ | ✓ |  | 64-bit Bitrig
 `x86_64-unknown-dragonfly` | ✓ | ✓ | ✓ | 64-bit DragonFlyBSD
 `x86_64-unknown-haiku` | ✓ | ✓ | ✓ | 64-bit Haiku
 `x86_64-unknown-hermit` | ? |  |  |

--- a/src/release/platform-support.md
+++ b/src/release/platform-support.md
@@ -77,14 +77,19 @@ target | std | rustc | cargo | notes
 `mips-unknown-linux-gnu` | ✓ | ✓ | ✓ | MIPS Linux
 `mips-unknown-linux-musl` | ✓ |  |  | MIPS Linux with MUSL
 `mips64-unknown-linux-gnuabi64` | ✓ | ✓ | ✓ | MIPS64 Linux, n64 ABI
+`mips64-unknown-linux-muslabi64` | ✓ |  |  | MIPS64 Linux, n64 ABI, MUSL
 `mips64el-unknown-linux-gnuabi64` | ✓ | ✓ | ✓ | MIPS64 (LE) Linux, n64 ABI
+`mips64el-unknown-linux-muslabi64` | ✓ |  |  | MIPS64 (LE) Linux, n64 ABI, MUSL
 `mipsel-unknown-linux-gnu` | ✓ | ✓ | ✓ | MIPS (LE) Linux
 `mipsel-unknown-linux-musl` | ✓ |  |  | MIPS (LE) Linux with MUSL
+`nvptx64-nvidia-cuda` | ✓ |  |  | --emit=asm generates PTX code that [runs on NVIDIA GPUs]
 `powerpc-unknown-linux-gnu` | ✓ | ✓ | ✓ | PowerPC Linux
 `powerpc64-unknown-linux-gnu` | ✓ | ✓ | ✓ | PPC64 Linux
 `powerpc64le-unknown-linux-gnu` | ✓ | ✓ | ✓ | PPC64LE Linux
+`riscv32i-unknown-none-elf` | * |  |  | Bare RISC-V (RV32I ISA)
 `riscv32imac-unknown-none-elf` | * |  |  | Bare RISC-V (RV32IMAC ISA)
 `riscv32imc-unknown-none-elf` | * |  |  | Bare RISC-V (RV32IMC ISA)
+`riscv64gc-unknown-linux-gnu` | ✓ | ✓ | ✓ | RISC-V Linux
 `riscv64gc-unknown-none-elf` | * |  |  | Bare RISC-V (RV64IMAFDC ISA)
 `riscv64imac-unknown-none-elf` | * |  |  | Bare RISC-V (RV64IMAC ISA)
 `s390x-unknown-linux-gnu` | ✓ | ✓ | ✓ | S390x Linux
@@ -96,6 +101,9 @@ target | std | rustc | cargo | notes
 `thumbv7m-none-eabi` | * |  |  | Bare Cortex-M3
 `thumbv7neon-linux-androideabi` | ✓ |  |  | Thumb2-mode ARMv7a Android with NEON
 `thumbv7neon-unknown-linux-gnueabihf` | ✓ |  |  | Thumb2-mode ARMv7a Linux with NEON
+`thumbv8m.base-none-eabi` | * |  |  | ARMv8-M Baseline
+`thumbv8m.main-none-eabi` | * |  |  | ARMv8-M Mainline
+`thumbv8m.main-none-eabihf` | * |  |  | ARMv8-M Baseline, hardfloat
 `wasm32-unknown-emscripten` | ✓ |  |  | WebAssembly via Emscripten
 `wasm32-unknown-unknown` | ✓ |  |  | WebAssembly
 `wasm32-wasi` | ✓ |  |  | WebAssembly with WASI
@@ -172,15 +180,12 @@ target | std | rustc | cargo | notes
 `i686-uwp-windows-msvc` | ? |  |  |
 `i686-wrs-vxworks` | ? |  |  |
 `mips-unknown-linux-uclibc` | ✓ |  |  | MIPS Linux with uClibc
-`mips64-unknown-linux-muslabi64` | ? |  |  |
-`mips64el-unknown-linux-muslabi64` | ? |  |  |
 `mipsel-unknown-linux-uclibc` | ✓ |  |  | MIPS (LE) Linux with uClibc
 `mipsisa32r6-unknown-linux-gnu` | ? |  |  |
 `mipsisa32r6el-unknown-linux-gnu` | ? |  |  |
 `mipsisa64r6-unknown-linux-gnuabi64` | ? |  |  |
 `mipsisa64r6el-unknown-linux-gnuabi64` | ? |  |  |
 `msp430-none-elf` | * |  |  | 16-bit MSP430 microcontrollers
-`nvptx64-nvidia-cuda` | ✓ |  |  | --emit=asm generates PTX code that [runs on NVIDIA GPUs]
 `powerpc-unknown-linux-musl` | ? |  |  |
 `powerpc-unknown-netbsd` | ? |  |  |
 `powerpc-wrs-vxworks` | ? |  |  |
@@ -189,15 +194,10 @@ target | std | rustc | cargo | notes
 `powerpc64-unknown-linux-musl` | ? |  |  |
 `powerpc64-wrs-vxworks` | ? |  |  |
 `powerpc64le-unknown-linux-musl` | ? |  |  |
-`riscv32i-unknown-none-elf` | ? |  |  |
-`riscv64gc-unknown-linux-gnu` | ✓ | ✓ | ✓ |
 `sparc64-unknown-netbsd` | ✓ | ✓ |  | NetBSD/sparc64
 `sparc64-unknown-openbsd` | ? |  |  |
 `thumbv7a-pc-windows-msvc` | ? |  |  |
 `thumbv7neon-unknown-linux-musleabihf` | ? |  |  | Thumb2-mode ARMv7a Linux with NEON, MUSL
-`thumbv8m.base-none-eabi` | ? |  |  |
-`thumbv8m.main-none-eabi` | ? |  |  |
-`thumbv8m.main-none-eabihf` | ? |  |  |
 `x86_64-apple-ios-macabi` | ✓ |  |  | Apple Catalyst
 `x86_64-apple-tvos` | ** | | | x86 64-bit tvOS
 `x86_64-linux-kernel` | ? |  |  | Linux kernel modules
@@ -215,7 +215,6 @@ target | std | rustc | cargo | notes
 `x86_64-uwp-windows-msvc` | ✓ |  |  |
 `x86_64-wrs-vxworks` | ? |  |  |
 
-[runs on NVIDIA GPUs]: https://github.com/japaric-archived/nvptx#targets
 
 \* These targets only support `core`, not `alloc` or `std`.
 
@@ -231,4 +230,5 @@ to the core library, Rust can also target additional "bare metal" platforms in
 the x86, ARM, MIPS, and PowerPC families, though it may require defining custom
 target specifications to do so.
 
+[runs on NVIDIA GPUs]: https://github.com/japaric-archived/nvptx#targets
 [Rust Forge repo]: https://github.com/rust-lang/rust-forge

--- a/src/release/platform-support.md
+++ b/src/release/platform-support.md
@@ -191,7 +191,6 @@ target | std | rustc | cargo | notes
 `thumbv8m.base-none-eabi` | ? |  |  |
 `thumbv8m.main-none-eabi` | ? |  |  |
 `thumbv8m.main-none-eabihf` | ? |  |  |
-`wasm32-experimental-emscripten` | ? |  |  |
 `x86_64-pc-solaris` | ? |  |  |
 `x86_64-pc-windows-msvc` | ✓ |  |  | 64-bit Windows XP support
 `x86_64-unknown-dragonfly` | ✓ | ✓ | ✓ | 64-bit DragonFlyBSD


### PR DESCRIPTION
This updates the platform tiers to the best of my knowledge.

**Tier 2 new**
* aarch64-unknown-none-softfloat  https://github.com/rust-lang/rust/pull/64589
* armv7-unknown-linux-gnueabi https://github.com/rust-lang/rust/pull/63107
* armv7-unknown-linux-musleabi https://github.com/rust-lang/rust/pull/63107

**Tier 3 removed**
* x86_64-unknown-bitrig https://github.com/rust-lang/rust/pull/60775
* wasm32-experimental-emscripten https://github.com/rust-lang/rust/pull/63649 (or https://github.com/rust-lang/rust/pull/65251)

**Tier 3 new**
* aarch64-apple-tvos  https://github.com/rust-lang/rust/pull/68191
* x86_64-apple-tvos  https://github.com/rust-lang/rust/pull/68191
* armv7a-none-eabihf  https://github.com/rust-lang/rust/pull/68253
* i686-unknown-uefi https://github.com/rust-lang/rust/pull/64334
* thumbv7neon-unknown-linux-musleabihf https://github.com/rust-lang/rust/pull/66103
* x86_64-apple-ios-macabi https://github.com/rust-lang/rust/pull/63467
* x86_64-linux-kernel https://github.com/rust-lang/rust/pull/64051
* x86_64-unknown-hermit-kernel https://github.com/rust-lang/rust/pull/66713
* x86_64-unknown-illumos https://github.com/rust-lang/rust/pull/71145

**Promoted Tier 3 to Tier 2**
* aarch64-unknown-none https://github.com/rust-lang/rust/pull/68334
* mips64-unknown-linux-muslabi64 https://github.com/rust-lang/rust/pull/65843
* mips64el-unknown-linux-muslabi64 https://github.com/rust-lang/rust/pull/65843
* nvptx64-nvidia-cuda https://github.com/rust-lang/rust/pull/57937
* riscv32i-unknown-none-elf https://github.com/rust-lang/rust/pull/62784
* riscv64gc-unknown-linux-gnu https://github.com/rust-lang/rust/pull/68037
* thumbv8m.base-none-eabi https://github.com/rust-lang/rust/pull/59182
* thumbv8m.main-none-eabi  https://github.com/rust-lang/rust/pull/56954
* thumbv8m.main-none-eabihf https://github.com/rust-lang/rust/pull/59182
