### PR TITLE
Fix correspondence between versions and dates in No Tools Breakage table

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -15,7 +15,7 @@ function addRelease (kind, incr, toolsWeek) {
   document.querySelector(`#${kind}-release-date`).textContent = `${releaseDate.format(DATE_FORMAT)} UTC`
 
   if (toolsWeek) {
-    const noBreakagesTo = releaseDate.clone().day(2)
+    const noBreakagesTo = releaseDate.clone().subtract(6, 'weeks').day(2)
     const noBreakagesFrom = noBreakagesTo.clone().subtract(6, 'days')
     const toDate = noBreakagesTo.format(DATE_FORMAT)
     const fromDate = noBreakagesFrom.format(DATE_FORMAT)
@@ -27,7 +27,7 @@ function addRelease (kind, incr, toolsWeek) {
 
 if (document.querySelector('#current-release-versions')) {
   addRelease('stable', 0, false)
-  addRelease('beta', 1, true)
+  addRelease('beta', 1, false)
   addRelease('nightly', 2, true)
   addRelease('next', 3, true)
 }

--- a/src/README.md
+++ b/src/README.md
@@ -46,10 +46,10 @@ Nightly +1 | <span id="next-version"></span>    | <span id="next-release-date"><
 To ensure the beta release includes all the tools, no [tool breakages] are
 allowed in the week before the beta cutoff (except for nightly-only tools).
 
-Channel | Version | No Breakage Week
---------|---------|-------------
-Beta    | <span id="beta-cycle"></span>    | <span id="beta-timespan"></span>
-Nightly | <span id="nightly-cycle"></span> | <span id="nightly-timespan"></span>
+Beta Cut | No Breakage Week
+---------|-----------------
+<span id="nightly-cycle"></span> | <span id="nightly-timespan"></span>
+<span id="next-cycle"></span>    | <span id="next-timespan"></span>
 
 [tool breakages]: ./infra/toolstate.md
 


### PR DESCRIPTION
The *No Tools Breakage Week* table didn't make sense to me. It currently says the "beta 1.44" no breakage week is May 27 &ndash; June 2. But beta 1.44 was cut a long time ago and is about to become stable 1.44. The relevant version number for the May 27 &ndash; June 2 date range is the 1.45 beta being cut.

Also the "Channel" column didn't seem applicable because every row is talking about a beta cut.

This also fixes a place that the js thought there were more rows in the table than the markdown did, causing a runtime type error.

<br>

## Before:

<p align="center">
<img width="70%" src="https://user-images.githubusercontent.com/1940490/83106913-21159580-a072-11ea-9df1-4ea121a914b3.png">
<br>
<img width="70%" src="https://user-images.githubusercontent.com/1940490/83106917-2377ef80-a072-11ea-982b-1990c0156b8a.png">
</p>

## After:

<p align="center">
<img width="70%" src="https://user-images.githubusercontent.com/1940490/83106926-25da4980-a072-11ea-830a-59c4cb5b9cff.png">
</p>