### PR TITLE
Update platform-support.md to include mipsel-sony-psp

### DIFF
--- a/src/release/platform-support.md
+++ b/src/release/platform-support.md
@@ -162,7 +162,7 @@ target | std | rustc | cargo | notes
 `i686-wrs-vxworks` | ? |  |  |
 `mips-unknown-linux-uclibc` | ✓ |  |  | MIPS Linux with uClibc
 `mipsel-unknown-linux-uclibc` | ✓ |  |  | MIPS (LE) Linux with uClibc
-`mipsel-sony-psp` | ? |  |  | MIPS (LE) Sony PlayStation Portable (PSP)
+`mipsel-sony-psp` | ** |  |  | MIPS (LE) Sony PlayStation Portable (PSP)
 `mipsisa32r6-unknown-linux-gnu` | ? |  |  |
 `mipsisa32r6el-unknown-linux-gnu` | ? |  |  |
 `mipsisa64r6-unknown-linux-gnuabi64` | ? |  |  |

--- a/src/release/platform-support.md
+++ b/src/release/platform-support.md
@@ -162,6 +162,7 @@ target | std | rustc | cargo | notes
 `i686-wrs-vxworks` | ? |  |  |
 `mips-unknown-linux-uclibc` | ✓ |  |  | MIPS Linux with uClibc
 `mipsel-unknown-linux-uclibc` | ✓ |  |  | MIPS (LE) Linux with uClibc
+`mipsel-sony-psp` | ? |  |  | MIPS (LE) Sony PlayStation Portable (PSP)
 `mipsisa32r6-unknown-linux-gnu` | ? |  |  |
 `mipsisa32r6el-unknown-linux-gnu` | ? |  |  |
 `mipsisa64r6-unknown-linux-gnuabi64` | ? |  |  |


### PR DESCRIPTION
Update platform-support.md to include mipsel-sony-psp
I took the name from https://github.com/rust-lang/rust/pull/72062.
I have no idea if it has std, rustc, cargo. I assumed it's Tier 3. @overdrivenpotato should know the details. :)