### PR TITLE
Add thumbv7a-uwp-windows-msvc to platform-support

### DIFF
--- a/src/release/platform-support.md
+++ b/src/release/platform-support.md
@@ -181,6 +181,7 @@ target | std | rustc | cargo | notes
 `sparc64-unknown-netbsd` | ✓ | ✓ |  | NetBSD/sparc64
 `sparc64-unknown-openbsd` | ? |  |  |
 `thumbv7a-pc-windows-msvc` | ? |  |  |
+`thumbv7a-uwp-windows-msvc` | ? |  |  |
 `thumbv7neon-unknown-linux-musleabihf` | ? |  |  | Thumb2-mode ARMv7a Linux with NEON, MUSL
 `x86_64-apple-ios-macabi` | ✓ |  |  | Apple Catalyst
 `x86_64-apple-tvos` | ** | | | x86 64-bit tvOS

--- a/src/release/platform-support.md
+++ b/src/release/platform-support.md
@@ -181,7 +181,7 @@ target | std | rustc | cargo | notes
 `sparc64-unknown-netbsd` | ✓ | ✓ |  | NetBSD/sparc64
 `sparc64-unknown-openbsd` | ? |  |  |
 `thumbv7a-pc-windows-msvc` | ? |  |  |
-`thumbv7a-uwp-windows-msvc` | ? |  |  |
+`thumbv7a-uwp-windows-msvc` | ✓ |  |  |
 `thumbv7neon-unknown-linux-musleabihf` | ? |  |  | Thumb2-mode ARMv7a Linux with NEON, MUSL
 `x86_64-apple-ios-macabi` | ✓ |  |  | Apple Catalyst
 `x86_64-apple-tvos` | ** | | | x86 64-bit tvOS


### PR DESCRIPTION
The target spec for `thumbv7a-uwp-windows-msvc` was added to the Rust codebase in https://github.com/rust-lang/rust/pull/72133. It should be documented as a Tier 3 target once added.

`libstd` built and worked out of the box, but some crates built only in `--release` builds. Therefore, the usability I assume is `?`.