### PR TITLE
Add avr-unknown-unknown to platform-support.md

### DIFF
--- a/src/release/platform-support.md
+++ b/src/release/platform-support.md
@@ -148,6 +148,7 @@ target | std | rustc | cargo | notes
 `armv7-wrs-vxworks-eabihf` | ? |  |  |
 `armv7a-none-eabihf` | * | | | ARM Cortex-A, hardfloat
 `armv7s-apple-ios` | ✓ |  |  |
+`avr-unknown-unknown` | ? |  |  | AVR
 `hexagon-unknown-linux-musl` | ? |  |  |
 `i386-apple-ios` | ✓ |  |  | 32-bit x86 iOS
 `i686-apple-darwin` | ✓ | ✓ | ✓ | 32-bit OSX (10.7+, Lion+)

--- a/src/release/platform-support.md
+++ b/src/release/platform-support.md
@@ -148,7 +148,7 @@ target | std | rustc | cargo | notes
 `armv7-wrs-vxworks-eabihf` | ? |  |  |
 `armv7a-none-eabihf` | * | | | ARM Cortex-A, hardfloat
 `armv7s-apple-ios` | ✓ |  |  |
-`avr-unknown-unknown` | ? |  |  | AVR
+`avr-unknown-unknown` | * |  |  | AVR
 `hexagon-unknown-linux-musl` | ? |  |  |
 `i386-apple-ios` | ✓ |  |  | 32-bit x86 iOS
 `i686-apple-darwin` | ✓ | ✓ | ✓ | 32-bit OSX (10.7+, Lion+)


### PR DESCRIPTION
I am not sure about details.
@dylanmckay would you be able to help out with them? Does it support core, alloc, or std?

AVR support PR: https://github.com/rust-lang/rust/pull/69478