### PR TITLE
Fix missing word in rollups.md

### DIFF
--- a/src/release/rollups.md
+++ b/src/release/rollups.md
@@ -6,7 +6,7 @@ The Rust project has a policy that every pull request must be tested after merge
 before it can be pushed to master. As PR volume increases this can scale poorly,
 especially given the long (~3.5hr) current CI duration for Rust.
 
-Enter rollups - changes that small, not performance sensitive, or not platform
+Enter rollups! Changes that are small, not performance sensitive, or not platform
 dependent are marked with the `rollup` command to bors (`@bors r+ rollup` to
 approve a PR and mark as a rollup, `@bors rollup` to mark a previously approved
 PR, `@bors rollup-` to un-mark as a rollup).  'Performing a Rollup' then means


### PR DESCRIPTION
Also makes a small edit to split into two sentences.