### PR TITLE
Add section on where to find libs team

### DIFF
--- a/src/libs/README.md
+++ b/src/libs/README.md
@@ -6,5 +6,3 @@ This section documents meta processes by the Libs team.
 
 The libs team hangs out primarily in [the rust-lang Zulip](https://rust-lang.zulipchat.com/) these days in the `#t-libs` stream.
 You can also find out more details about [Zulip and how the Rust community uses it](../../chat/zulip.html).
-
-The `#rustc` IRC channel on `irc.mozilla.org` is in a "quasi-deprecated" status and is not recommended.

--- a/src/libs/README.md
+++ b/src/libs/README.md
@@ -5,5 +5,6 @@ This section documents meta processes by the Libs team.
 ## Where to find us
 
 The libs team hangs out primarily in [the rust-lang Zulip](https://rust-lang.zulipchat.com/) these days in the `#t-libs` stream.
+You can find more details about Zulip and how the Rust community uses it [here](../../chat/zulip).
 
 The `#rustc` IRC channel on `irc.mozilla.org` is in a "quasi-deprecated" status and is not recommended.

--- a/src/libs/README.md
+++ b/src/libs/README.md
@@ -1,3 +1,9 @@
 # Libs
-This section documents meta processes by the libs team.
 
+This section documents meta processes by the Libs team.
+
+## Where to find us
+
+The libs team hangs out primarily in [the rust-lang Zulip](https://rust-lang.zulipchat.com/) these days in the `#t-libs` stream.
+
+The `#rustc` IRC channel on `irc.mozilla.org` is in a "quasi-deprecated" status and is not recommended.

--- a/src/libs/README.md
+++ b/src/libs/README.md
@@ -5,6 +5,6 @@ This section documents meta processes by the Libs team.
 ## Where to find us
 
 The libs team hangs out primarily in [the rust-lang Zulip](https://rust-lang.zulipchat.com/) these days in the `#t-libs` stream.
-You can find more details about Zulip and how the Rust community uses it [here](../../chat/zulip).
+You can also find out more details about [Zulip and how the Rust community uses it](../../chat/zulip.html).
 
 The `#rustc` IRC channel on `irc.mozilla.org` is in a "quasi-deprecated" status and is not recommended.


### PR DESCRIPTION
Adds a note about the `#t-libs` stream on Zulip, based on https://rust-lang.github.io/compiler-team/about/chat-platform/

cc @rust-lang/libs 