### PR TITLE
describe how to create a notification group

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -18,6 +18,7 @@
     - [So you want to add a new option to rustc?](./compiler/new_option.md)
     - [Major Change Proposals](./compiler/mcp.md)
     - [Membership](./compiler/membership.md)
+    - [Notification groups](./compiler/notification-groups.md)
     - [Triage Meeting](./compiler/triage-meeting.md)
     - [Steering Meeting](./compiler/steering-meeting.md)
         - [Submitting a proposal](./compiler/steering-meeting/submit.md)

--- a/src/compiler/notification-groups.md
+++ b/src/compiler/notification-groups.md
@@ -17,7 +17,7 @@ First, you want to get approval from the compiler team:
   notification group. Often this is an existing label, such as
   `O-Windows`.
   
-Once the MCP is seconded, here are the steps to actually create the group.
+Once the MCP is accepted, here are the steps to actually create the group.
 In some cases we include an example PR from some other group. 
 
 * File a tracking issue in the rust-lang/compiler-team repository to collect

--- a/src/compiler/notification-groups.md
+++ b/src/compiler/notification-groups.md
@@ -13,7 +13,7 @@ First, you want to get approval:
   your group is not analogous to some existing group, it is probably
   a good idea to ping compiler team leads before-hand or as part of
   the MCP.
-* The MCP should specify what Github label will be associated with the
+* The MCP should specify what GitHub label will be associated with the
   notification group. Often this is an existing label, such as
   `O-Windows`.
   

--- a/src/compiler/notification-groups.md
+++ b/src/compiler/notification-groups.md
@@ -1,0 +1,39 @@
+# Notification groups
+
+The compiler team has a number of notification groups that we use to
+ping people and draw their attention to issues. Notification groups
+are setup so that anyone can join them if they want.
+
+## Creating a notification group
+
+If you'd like to create a notification group, here are the steps.
+First, you want to get approval:
+
+* Propose the group by preparing a [Major Change Proposal][MCP].  If
+  you're group is not analogous to some existing group, it is probably
+  a good idea to ping compiler team leads before-hand or as part of
+  the MCP.
+* The MCP should specify what Github label will be associated with the
+  notification group. Often this is an existing label, such as
+  `O-Windows`.
+  
+Once the MCP is seconded, here are the steps to actually create the group.
+In some cases we include an example PR from some other group. 
+
+* File a tracking issue in the rust-lang/compiler-team repository to collect
+  your progress.
+* Create a PR against the rust-lang/team repository adding the notification
+  group. [Example PR.](https://github.com/rust-lang/team/pull/347)
+* Configure the rust-lang/rust repository to accept triagebot commands
+  for this group. [Example PR.](https://github.com/rust-lang/rust/pull/72706)
+* Create a PR for the rustc-dev-guide amending [the notification group
+  section](https://rustc-dev-guide.rust-lang.org/notification-groups/about.html)
+  to mention your group.
+* Create a sample PR for the rust-lang/team repository showing how one can add
+  oneself. This will be referenced by your blog post to show people how to 
+  join. [Example PR.](https://github.com/rust-lang/team/pull/140)
+* Write an announcement blog post for Inside Rust and open a PR against
+  [blog.rust-lang.org](https://github.com/rust-lang/blog.rust-lang.org).
+  [Example PR.](https://github.com/rust-lang/blog.rust-lang.org/pull/615)
+
+[MCP]: ./mcp.md

--- a/src/compiler/notification-groups.md
+++ b/src/compiler/notification-groups.md
@@ -10,7 +10,7 @@ If you'd like to create a notification group, here are the steps.
 First, you want to get approval:
 
 * Propose the group by preparing a [Major Change Proposal][MCP].  If
-  you're group is not analogous to some existing group, it is probably
+  your group is not analogous to some existing group, it is probably
   a good idea to ping compiler team leads before-hand or as part of
   the MCP.
 * The MCP should specify what Github label will be associated with the

--- a/src/compiler/notification-groups.md
+++ b/src/compiler/notification-groups.md
@@ -7,7 +7,7 @@ are setup so that anyone can join them if they want.
 ## Creating a notification group
 
 If you'd like to create a notification group, here are the steps.
-First, you want to get approval:
+First, you want to get approval from the compiler team:
 
 * Propose the group by preparing a [Major Change Proposal][MCP].  If
   your group is not analogous to some existing group, it is probably


### PR DESCRIPTION
Sample PR. I'm considering moving the list of steps into the compiler-team repository, though, as a template tracking issue. Maybe that'd be better.