### PR TITLE
Fix contents link on other-installation-methods

### DIFF
--- a/src/infra/other-installation-methods.md
+++ b/src/infra/other-installation-methods.md
@@ -3,7 +3,7 @@
 - [Which installer should you use?](#which)
 - [Other ways to install `rustup`](#more-rustup)
 - [Standalone installers](#standalone)
-- [Source code](#source)
+- [Source code](#source-code)
 
 ## Which installer should you use?
 


### PR DESCRIPTION
#source is not a valid heading link