### PR TITLE
Platform Support: update kernel/glibc versions for linux-gnu targets

### DIFF
--- a/src/release/platform-support.md
+++ b/src/release/platform-support.md
@@ -46,13 +46,13 @@ target | std | rustc | cargo | notes
 `aarch64-fuchsia` | ✓ |  |  | ARM64 Fuchsia
 `aarch64-linux-android` | ✓ |  |  | ARM64 Android
 `aarch64-pc-windows-msvc` | ✓ |  |  | ARM64 Windows MSVC
-`aarch64-unknown-linux-gnu` | ✓ | ✓ | ✓ | ARM64 Linux
+`aarch64-unknown-linux-gnu` | ✓ | ✓ | ✓ | ARM64 Linux (kernel 4.2, glibc 2.17)
 `aarch64-unknown-linux-musl` | ✓ |  |  | ARM64 Linux with MUSL
 `aarch64-unknown-none` | * |  |  | Bare ARM64, hardfloat
 `aarch64-unknown-none-softfloat` | * |  |  | Bare ARM64, softfloat
 `arm-linux-androideabi` | ✓ |  |  | ARMv7 Android
-`arm-unknown-linux-gnueabi` | ✓ | ✓ | ✓ | ARMv6 Linux
-`arm-unknown-linux-gnueabihf` | ✓ | ✓ | ✓ | ARMv6 Linux, hardfloat
+`arm-unknown-linux-gnueabi` | ✓ | ✓ | ✓ | ARMv6 Linux (kernel 3.2, glibc 2.17)
+`arm-unknown-linux-gnueabihf` | ✓ | ✓ | ✓ | ARMv6 Linux, hardfloat (kernel 3.2, glibc 2.17)
 `arm-unknown-linux-musleabi` | ✓ |  |  | ARMv6 Linux with MUSL
 `arm-unknown-linux-musleabihf` | ✓ |  |  | ARMv6 Linux with MUSL, hardfloat
 `armebv7r-none-eabi` | * |  |  | Bare ARMv7-R, Big Endian
@@ -64,7 +64,7 @@ target | std | rustc | cargo | notes
 `armv7r-none-eabi` | * |  |  | Bare ARMv7-R
 `armv7r-none-eabihf` | * |  |  | Bare ARMv7-R, hardfloat
 `armv7-unknown-linux-gnueabi` | ✓ |   |   | ARMv7 Linux, glibc
-`armv7-unknown-linux-gnueabihf` | ✓ | ✓ | ✓ | ARMv7 Linux, hardfloat
+`armv7-unknown-linux-gnueabihf` | ✓ | ✓ | ✓ | ARMv7 Linux, hardfloat (kernel 3.2, glibc 2.17)
 `armv7-unknown-linux-musleabi` | ✓ |   |   | ARMv7 Linux, MUSL
 `armv7-unknown-linux-musleabihf` | ✓ |  |  | ARMv7 Linux with MUSL
 `asmjs-unknown-emscripten` | ✓ |  |  | asm.js via Emscripten
@@ -83,16 +83,16 @@ target | std | rustc | cargo | notes
 `mipsel-unknown-linux-gnu` | ✓ | ✓ | ✓ | MIPS (LE) Linux
 `mipsel-unknown-linux-musl` | ✓ |  |  | MIPS (LE) Linux with MUSL
 `nvptx64-nvidia-cuda` | ✓ |  |  | --emit=asm generates PTX code that [runs on NVIDIA GPUs]
-`powerpc-unknown-linux-gnu` | ✓ | ✓ | ✓ | PowerPC Linux
-`powerpc64-unknown-linux-gnu` | ✓ | ✓ | ✓ | PPC64 Linux
-`powerpc64le-unknown-linux-gnu` | ✓ | ✓ | ✓ | PPC64LE Linux
+`powerpc-unknown-linux-gnu` | ✓ | ✓ | ✓ | PowerPC Linux (kernel 2.6.32, glibc 2.12)
+`powerpc64-unknown-linux-gnu` | ✓ | ✓ | ✓ | PPC64 Linux (kernel 2.6.32, glibc 2.12)
+`powerpc64le-unknown-linux-gnu` | ✓ | ✓ | ✓ | PPC64LE Linux (kernel 3.10, glibc 2.17)
 `riscv32i-unknown-none-elf` | * |  |  | Bare RISC-V (RV32I ISA)
 `riscv32imac-unknown-none-elf` | * |  |  | Bare RISC-V (RV32IMAC ISA)
 `riscv32imc-unknown-none-elf` | * |  |  | Bare RISC-V (RV32IMC ISA)
-`riscv64gc-unknown-linux-gnu` | ✓ | ✓ | ✓ | RISC-V Linux
+`riscv64gc-unknown-linux-gnu` | ✓ | ✓ | ✓ | RISC-V Linux (kernel 4.20, glibc 2.29)
 `riscv64gc-unknown-none-elf` | * |  |  | Bare RISC-V (RV64IMAFDC ISA)
 `riscv64imac-unknown-none-elf` | * |  |  | Bare RISC-V (RV64IMAC ISA)
-`s390x-unknown-linux-gnu` | ✓ | ✓ | ✓ | S390x Linux
+`s390x-unknown-linux-gnu` | ✓ | ✓ | ✓ | S390x Linux (kernel 2.6.32, glibc 2.12)
 `sparc64-unknown-linux-gnu` | ✓ |  |  | SPARC Linux
 `sparcv9-sun-solaris` | ✓ |  |  | SPARC Solaris 10/11, illumos
 `thumbv6m-none-eabi` | * |  |  | Bare Cortex-M0, M0+, M1

--- a/src/release/platform-support.md
+++ b/src/release/platform-support.md
@@ -63,7 +63,7 @@ target | std | rustc | cargo | notes
 `armv7a-none-eabi` | * |  |  | Bare ARMv7-A
 `armv7r-none-eabi` | * |  |  | Bare ARMv7-R
 `armv7r-none-eabihf` | * |  |  | Bare ARMv7-R, hardfloat
-`armv7-unknown-linux-gnueabi` | ✓ |   |   | ARMv7 Linux, glibc
+`armv7-unknown-linux-gnueabi` | ✓ |   |   | ARMv7 Linux (kernel 4.15, glibc 2.27)
 `armv7-unknown-linux-gnueabihf` | ✓ | ✓ | ✓ | ARMv7 Linux, hardfloat (kernel 3.2, glibc 2.17)
 `armv7-unknown-linux-musleabi` | ✓ |   |   | ARMv7 Linux, MUSL
 `armv7-unknown-linux-musleabihf` | ✓ |  |  | ARMv7 Linux with MUSL
@@ -115,7 +115,7 @@ target | std | rustc | cargo | notes
 `x86_64-sun-solaris` | ✓ |  |  | 64-bit Solaris 10/11, illumos
 `x86_64-unknown-cloudabi` | ✓ |  |  | 64-bit CloudABI
 `x86_64-unknown-freebsd` | ✓ | ✓ | ✓ | 64-bit FreeBSD
-`x86_64-unknown-linux-gnux32` | ✓ |  |  | 64-bit Linux (x32 ABI)
+`x86_64-unknown-linux-gnux32` | ✓ |  |  | 64-bit Linux (x32 ABI) (kernel 4.15, glibc 2.27)
 `x86_64-unknown-linux-musl` | ✓ | ✓ | ✓ | 64-bit Linux with MUSL
 `x86_64-unknown-netbsd` | ✓ | ✓ | ✓ | NetBSD/amd64
 `x86_64-unknown-redox` | ✓ |  |  | Redox OS

--- a/src/release/platform-support.md
+++ b/src/release/platform-support.md
@@ -57,7 +57,7 @@ target | std | rustc | cargo | notes
 `arm-unknown-linux-musleabihf` | ✓ |  |  | ARMv6 Linux with MUSL, hardfloat
 `armebv7r-none-eabi` | * |  |  | Bare ARMv7-R, Big Endian
 `armebv7r-none-eabihf` | * |  |  | Bare ARMv7-R, Big Endian, hardfloat
-`armv5te-unknown-linux-gnueabi` | ✓ |  |  | ARMv5TE Linux
+`armv5te-unknown-linux-gnueabi` | ✓ |  |  | ARMv5TE Linux (kernel 4.4, glibc 2.23)
 `armv5te-unknown-linux-musleabi` | ✓ |  |  | ARMv5TE Linux with MUSL
 `armv7-linux-androideabi` | ✓ |  |  | ARMv7a Android
 `armv7a-none-eabi` | * |  |  | Bare ARMv7-A
@@ -69,18 +69,18 @@ target | std | rustc | cargo | notes
 `armv7-unknown-linux-musleabihf` | ✓ |  |  | ARMv7 Linux with MUSL
 `asmjs-unknown-emscripten` | ✓ |  |  | asm.js via Emscripten
 `i586-pc-windows-msvc` | ✓ |  |  | 32-bit Windows w/o SSE
-`i586-unknown-linux-gnu` | ✓ |  |  | 32-bit Linux w/o SSE
+`i586-unknown-linux-gnu` | ✓ |  |  | 32-bit Linux w/o SSE (kernel 4.4, glibc 2.23)
 `i586-unknown-linux-musl` | ✓ |  |  | 32-bit Linux w/o SSE, MUSL
 `i686-linux-android` | ✓ |  |  | 32-bit x86 Android
 `i686-unknown-freebsd` | ✓ | ✓ | ✓ | 32-bit FreeBSD
 `i686-unknown-linux-musl` | ✓ |  |  | 32-bit Linux with MUSL
-`mips-unknown-linux-gnu` | ✓ | ✓ | ✓ | MIPS Linux
+`mips-unknown-linux-gnu` | ✓ | ✓ | ✓ | MIPS Linux (kernel 4.4, glibc 2.23)
 `mips-unknown-linux-musl` | ✓ |  |  | MIPS Linux with MUSL
-`mips64-unknown-linux-gnuabi64` | ✓ | ✓ | ✓ | MIPS64 Linux, n64 ABI
+`mips64-unknown-linux-gnuabi64` | ✓ | ✓ | ✓ | MIPS64 Linux, n64 ABI (kernel 4.4, glibc 2.23)
 `mips64-unknown-linux-muslabi64` | ✓ |  |  | MIPS64 Linux, n64 ABI, MUSL
-`mips64el-unknown-linux-gnuabi64` | ✓ | ✓ | ✓ | MIPS64 (LE) Linux, n64 ABI
+`mips64el-unknown-linux-gnuabi64` | ✓ | ✓ | ✓ | MIPS64 (LE) Linux, n64 ABI (kernel 4.4, glibc 2.23)
 `mips64el-unknown-linux-muslabi64` | ✓ |  |  | MIPS64 (LE) Linux, n64 ABI, MUSL
-`mipsel-unknown-linux-gnu` | ✓ | ✓ | ✓ | MIPS (LE) Linux
+`mipsel-unknown-linux-gnu` | ✓ | ✓ | ✓ | MIPS (LE) Linux (kernel 4.4, glibc 2.23)
 `mipsel-unknown-linux-musl` | ✓ |  |  | MIPS (LE) Linux with MUSL
 `nvptx64-nvidia-cuda` | ✓ |  |  | --emit=asm generates PTX code that [runs on NVIDIA GPUs]
 `powerpc-unknown-linux-gnu` | ✓ | ✓ | ✓ | PowerPC Linux (kernel 2.6.32, glibc 2.12)
@@ -93,14 +93,14 @@ target | std | rustc | cargo | notes
 `riscv64gc-unknown-none-elf` | * |  |  | Bare RISC-V (RV64IMAFDC ISA)
 `riscv64imac-unknown-none-elf` | * |  |  | Bare RISC-V (RV64IMAC ISA)
 `s390x-unknown-linux-gnu` | ✓ | ✓ | ✓ | S390x Linux (kernel 2.6.32, glibc 2.12)
-`sparc64-unknown-linux-gnu` | ✓ |  |  | SPARC Linux
+`sparc64-unknown-linux-gnu` | ✓ |  |  | SPARC Linux (kernel 4.4, glibc 2.23)
 `sparcv9-sun-solaris` | ✓ |  |  | SPARC Solaris 10/11, illumos
 `thumbv6m-none-eabi` | * |  |  | Bare Cortex-M0, M0+, M1
 `thumbv7em-none-eabi` | * |  |  | Bare Cortex-M4, M7
 `thumbv7em-none-eabihf` | * |  |  | Bare Cortex-M4F, M7F, FPU, hardfloat
 `thumbv7m-none-eabi` | * |  |  | Bare Cortex-M3
 `thumbv7neon-linux-androideabi` | ✓ |  |  | Thumb2-mode ARMv7a Android with NEON
-`thumbv7neon-unknown-linux-gnueabihf` | ✓ |  |  | Thumb2-mode ARMv7a Linux with NEON
+`thumbv7neon-unknown-linux-gnueabihf` | ✓ |  |  | Thumb2-mode ARMv7a Linux with NEON (kernel 4.4, glibc 2.23)
 `thumbv8m.base-none-eabi` | * |  |  | ARMv8-M Baseline
 `thumbv8m.main-none-eabi` | * |  |  | ARMv8-M Mainline
 `thumbv8m.main-none-eabihf` | * |  |  | ARMv8-M Baseline, hardfloat

--- a/src/release/platform-support.md
+++ b/src/release/platform-support.md
@@ -22,11 +22,11 @@ target | std | rustc | cargo | notes
 -------|-----|-------|-------|-------
 `i686-pc-windows-gnu` | ✓ | ✓ | ✓ | 32-bit MinGW (Windows 7+)
 `i686-pc-windows-msvc` | ✓ | ✓ | ✓ | 32-bit MSVC (Windows 7+)
-`i686-unknown-linux-gnu` | ✓ | ✓ | ✓ | 32-bit Linux (2.6.18+)
+`i686-unknown-linux-gnu` | ✓ | ✓ | ✓ | 32-bit Linux (kernel 2.6.32+, glibc 2.11+)
 `x86_64-apple-darwin` | ✓ | ✓ | ✓ | 64-bit OSX (10.7+, Lion+)
 `x86_64-pc-windows-gnu` | ✓ | ✓ | ✓ | 64-bit MinGW (Windows 7+)
 `x86_64-pc-windows-msvc` | ✓ | ✓ | ✓ | 64-bit MSVC (Windows 7+)
-`x86_64-unknown-linux-gnu` | ✓ | ✓ | ✓ | 64-bit Linux (2.6.18+)
+`x86_64-unknown-linux-gnu` | ✓ | ✓ | ✓ | 64-bit Linux (kernel 2.6.32+, glibc 2.11+)
 
 ## Tier 2
 Tier 2 platforms can be thought of as "guaranteed to build". Automated tests


### PR DESCRIPTION
- i686 and x86_64 updated to kernel 2.6.32 and glibc 2.11 in <https://github.com/rust-lang/rust/pull/74163>.
- Targets that use crosstool-ng or similar now list their configured support.
- Targets that are built with Ubuntu 16.04 toolchains now list kernel 4.4 and glibc 2.17.
- Targets that are built with Ubuntu 18.04 toolchains now list kernel 4.15 and glibc 2.27.
- Tier-3 targets still have no specified support, since they don't build dist.