### PR TITLE
link to proposals page from main steering-meeting page

### DIFF
--- a/src/compiler/steering-meeting.md
+++ b/src/compiler/steering-meeting.md
@@ -24,6 +24,11 @@ topic, if that topic is complex. **Week 4 is reserved for
 non-technical topics**, so as to ensure that we are keeping an eye on
 the overall health and functioning of the team.
 
+### Where do proposals come from?
+
+The team accepts proposals via an open submission process,
+which is documented on [its own page](steering-meeting/submit.md)
+
 ## Announcing the schedule
 
 After each planning meeting, the topics for the next three weeks are


### PR DESCRIPTION
link to proposals page so that the main steering-meeting page has "everything" in one place.

(The motivation for this is to provide a usable target page for other pages
outside forge, such as the compiler-team site, that want to explain the steering
meeting.)