### PR TITLE
Add note about PhantomData and dropck

### DIFF
--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -202,6 +202,7 @@ struct OptionCell<T> {
 impl<T> Drop for OptionCell<T> {
     fn drop(&mut self) {
         if self.is_init {
+            // Safety: `value` is guaranteed to be fully initialized when `is_init` is true.
             // Safety: The cell is being dropped, so it can't be accessed again.
             drop(unsafe { self.value.read() });
         }

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -204,7 +204,7 @@ struct OptionCell<T> {
 }
 ```
 
-Types in the standard library that use the internal `Unique<T>` will don't need a `PhantomData` marker field. That's taken care of for them by `Unique<T>`.
+Types in the standard library that use the internal `Unique<T>` don't need a `PhantomData` marker field. That's taken care of for them by `Unique<T>`.
 
 ### How could `mem` break assumptions?
 

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -201,8 +201,10 @@ struct OptionCell<T> {
 
 impl<T> Drop for OptionCell<T> {
     fn drop(&mut self) {
-        // Safety: The cell is being dropped, so it can't be accessed again.
-        unsafe { self.take_inner() };
+        if self.is_init {
+            // Safety: The cell is being dropped, so it can't be accessed again.
+            let _ = unsafe { self.value.read() };
+        }
     }
 }
 ```

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -203,7 +203,7 @@ impl<T> Drop for OptionCell<T> {
     fn drop(&mut self) {
         if self.is_init {
             // Safety: The cell is being dropped, so it can't be accessed again.
-            let _ = unsafe { self.value.read() };
+            drop(unsafe { self.value.read() });
         }
     }
 }

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -229,7 +229,7 @@ struct OptionCell<T> {
 }
 
 - impl Drop<T> for OptionCell<T> {
-+ unsafe impl Drop<#[may_dangle] T> for OptionCell<T> {
++ unsafe impl<#[may_dangle] T> Drop for OptionCell<T> {
 ```
 
 ### How could `mem` break assumptions?

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -199,7 +199,7 @@ struct OptionCell<T> {
     value: MaybeUninit<T>,
 }
 
-impl Drop<T> for OptionCell<T> {
+impl<T> Drop for OptionCell<T> {
     fn drop(&mut self) {
         // Safety: The cell is being dropped, so it can't be accessed again.
         unsafe { self.take_inner() };


### PR DESCRIPTION
Based on a soundness issue with `SyncOnceCell` introduced when we added a `#[may_dangle]` attribute without also informing dropck that we logically own the value: https://github.com/rust-lang/rust/issues/76367

cc @matklad @m-ou-se

r? @RalfJung 