### PR TITLE
Fix incorrect backtick usage in inline code

### DIFF
--- a/src/release/process.md
+++ b/src/release/process.md
@@ -63,7 +63,7 @@ We need to find out the parent commit in which the PR opened last Monday merged.
 
 Go to that PR, and find the "bors merged commit $SHA into rust-lang:master at the bottom.
 
-Locally, run `export BRANCH_POINT=`git rev-parse $SHA^` in the rust-lang/rust
+Locally, run `` export BRANCH_POINT=`git rev-parse $SHA^` `` in the rust-lang/rust
 checkout. This should be bors-authored merge into master of the PR before the
 version bump merged.
 


### PR DESCRIPTION
Just a small formatting/markdown fix. [Rendered diff](https://github.com/rust-lang/rust-forge/pull/436/files?short_path=c6102a0#diff-c6102a095154b31981d16ec43db953ca) says it all.