### PR TITLE
Don't single out intra-doc links as causing rollups to fail

### DIFF
--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -249,7 +249,7 @@ PRs to [`rust-lang/rust`] aren’t merged manually using GitHub’s UI or by pus
 
 ### When to `rollup`
 
-For Libs PRs, rolling up is usually fine, in particular if it's only a new unstable addition or if it only touches docs (with the exception of intra doc links which complicates things while the feature has bugs...).
+For Libs PRs, rolling up is usually fine, in particular if it's only a new unstable addition or if it only touches docs.
 
 See the [rollup guidelines] for more details on when to rollup.
 


### PR DESCRIPTION
There have been a lot of bugs fixed in intra-doc links lately and they are being stabilized in the next release. Additionally, almost all intra-doc issues are caught in the PR build, before they get to bors; the only exceptions I can think of have to do with `cfg(platform)`, which should be comparatively rare (https://github.com/rust-lang/rust/issues/76526) and no more likely to fail than linkcheck failures.