### PR TITLE
Updates to Libs docs

### DIFF
--- a/src/libs/README.md
+++ b/src/libs/README.md
@@ -4,15 +4,9 @@ This section documents meta processes by the Libs team.
 
 ## Where to find us
 
-The libs team hangs out primarily in [the rust-lang Zulip](https://rust-lang.zulipchat.com/) these days in the `#t-libs` stream.
+The [`rust-lang/libs-team`](https://github.com/rust-lang/libs-team) GitHub repository is the home of the Libs team.
+It has details on current project groups, upcoming meetings, and the status of tracking issues.
+
+The Libs team hangs out primarily in [the rust-lang Zulip](https://rust-lang.zulipchat.com/) these days in the `#t-libs` stream.
 
 You can also find out more details about [Zulip and how the Rust community uses it](../../platforms/zulip.html).
-
-## Useful GitHub queries
-
-The Libs team does its work in a number of repositories throughout the `rust-lang` organization and others on GitHub.
-
-| Query | Description |
-|----------|------ |
-| [Open Libs RFCs](https://github.com/rust-lang/rfcs/pulls?q=is%3Apr+is%3Aopen+label%3AT-libs) | RFCs that need input from the Libs team. |
-| [Open Libs PRs](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+label%3AT-libs) | PRs that need input from the Libs team. |


### PR DESCRIPTION
This PR makes a few drive-by changes to our Libs docs:

- Links to the new `rust-lang/libs-team` repository.
- Adds an example of private specialization and removes the note that we can't use it (now that we have `min_specialization`)
- Stubs out a section on const generics.

r? @scottmcm on the specialization comments. Do those look good to you from a libs-impl perspective?