### PR TITLE
Remove wg checkins text from notify team section

### DIFF
--- a/src/compiler/prioritization/procedure.md
+++ b/src/compiler/prioritization/procedure.md
@@ -122,9 +122,9 @@ Create `[weekly meeting] YYYY-MM-DD #54818` topic in `#t-compiler/meetings` Zuli
 
 ```text
 Hi @*T-compiler/meeting*; the triage meeting will happen tomorrow at <time:YYYY-MM-DDT14:00:00+00:00>
-**WG-prioritization** has done pre-triage in #**t-compiler/wg-prioritization/alerts**
+*WG-prioritization* has done pre-triage in #**t-compiler/wg-prioritization/alerts**
 @*WG-prioritization* has prepared the [meeting agenda](link_to_hackmd_agenda)
-We will have checkins from @*WG-X* and @*WG-Y*
+We will have checkins from *WG-X* and *WG-Y*
 @**person1** do you have something you want to share about @*WG-X*?
 @**person2** do you have something you want to share about @*WG-Y*?
 ```

--- a/src/compiler/prioritization/procedure.md
+++ b/src/compiler/prioritization/procedure.md
@@ -118,7 +118,6 @@ Add [Triage Logs](https://github.com/rust-lang/rustc-perf/tree/master/triage#tri
 
 ### Notify the team about the meeting
 
-[Figure out which working groups' check-ins follow](https://rust-lang.github.io/compiler-team/about/triage-meeting/).
 Create `[weekly meeting] YYYY-MM-DD #54818` topic in `#t-compiler/meetings` Zulip's stream and send the following messages:
 
 ```text


### PR DESCRIPTION
That part of the process lives now in the `Follow ups from previous meeting` section.
And have also modified the mentions to working groups on the notify compiler team section.

r? @XAMPPRocky 