### PR TITLE
Update example for new interface of MaybeUninit.

### DIFF
--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -260,7 +260,7 @@ impl<T> Drop for OptionCell<T> {
         if self.is_init {
             // Safety: `value` is guaranteed to be fully initialized when `is_init` is true.
             // Safety: The cell is being dropped, so it can't be accessed again.
-            drop(unsafe { self.value.read() });
+            unsafe { self.value.assume_init_drop() };
         }
     }
 }


### PR DESCRIPTION
`MaybeUninit` no longer has a `.read()` function; it was renamed to `.assume_init_read()`. But it also has a `.assume_init_drop()` now, which is a better fit for this example.