### PR TITLE
Update links to the bors queue

### DIFF
--- a/src/infra/docs/rustc-ci.md
+++ b/src/infra/docs/rustc-ci.md
@@ -70,7 +70,7 @@ of PRs we can merge in a day is 7.
 
 [bors]: https://github.com/bors
 [homu]: https://github.com/rust-lang/homu
-[homu-queue]: https://buildbot2.rust-lang.org/homu/queue/rust
+[homu-queue]: https://bors.rust-lang.org/queue/rust
 
 ### Rollups
 

--- a/src/infra/service-infrastructure.md
+++ b/src/infra/service-infrastructure.md
@@ -31,11 +31,11 @@ request. It is run by [TimNN](https://github.com/TimNN).
 requests. It is often referred to as "bors" due to the name of its
 [bot user account](https://github.com/bors).
 Approved pull requests are placed in
-[a queue](http://buildbot2.rust-lang.org/homu/queue/rust) from which tests are
+[a queue](http://bors.rust-lang.org/queue/rust) from which tests are
 run.
 
 Documentation on homu commands can be found
-[here](http://buildbot2.rust-lang.org/homu/).
+[here](http://bors.rust-lang.org/).
 
 Please contact [Alex Crichton](https://github.com/alexcrichton) if something
 goes wrong with the bot.

--- a/src/release/README.md
+++ b/src/release/README.md
@@ -17,5 +17,5 @@ support.
 
 [Rustup Component History]: https://rust-lang.github.io/rustup-components-history/index.html
 [PR Tracking]: https://rust-lang-nursery.github.io/rustc-pr-tracking/
-[Homu/Bors]: https://buildbot2.rust-lang.org/homu/
+[Homu/Bors]: https://bors.rust-lang.org/
 [`rustup-toolchain-install-master`]: https://github.com/kennytm/rustup-toolchain-install-master

--- a/src/release/rollups.md
+++ b/src/release/rollups.md
@@ -73,5 +73,5 @@ or confirm your hypothesis.
 If a rollup continues to fail you can run the `@bors rollup=never` command to
 never rollup the PR in question.
 
-[Homu queue]: https://buildbot2.rust-lang.org/homu/queue/rust
+[Homu queue]: https://bors.rust-lang.org/queue/rust
 [the Rollups section]: ../compiler/reviews.md#rollups


### PR DESCRIPTION
I found that the links weren't updated when reading the rollup procedure :)