### PR TITLE
Fix outdated repository references for linkifiers

### DIFF
--- a/src/platforms/zulip.md
+++ b/src/platforms/zulip.md
@@ -171,11 +171,11 @@ We currently support linking to issues on a few repositories:
 * rust-lang/rust with [`#4545`](https://github.com/rust-lang/rust/issues/4545) or `rust#4545`
 * rust-lang/rfcs with `RFC#3434` or `rfc#3434`
 * rust-lang/async-book with `async-book#2334`
-* rust-lang-nursery/chalk with `chalk#2334`
+* rust-lang/chalk with `chalk#2334`
 * rust-lang/compiler-team with `compiler-team#3433`
-* rust-lang-nursery/ena with `ena#3434`
+* rust-lang/ena with `ena#3434`
 * rust-lang/miri with `miri#3434`
-* rust-lang-nursery/polonius with `polonius#3434`
+* rust-lang/polonius with `polonius#3434`
 * rust-analyzer/rust-analyzer with `rust-analyzer#3434`
 * rust-lang/rustc-dev-guide with `rustc-dev-guide#3434`
 * rust-lang/stdarch with `stdarch#3434`


### PR DESCRIPTION
The Github repository references that describe which repositories have supported short linkifier notations were outdated for chalk, ena and polonius.
All three projects are no longer in rust-lang-nursery but in rust-lang. The resulting links will still work but might confuse new users.
The current linkifier settings for rust-lang.zulipchat.com already use the updated link for chalk but not for the other two.

Addresses the first part of #476 .