### PR TITLE
Filter out more teams on No team prioritization checks

### DIFF
--- a/src/compiler/prioritization/procedure.md
+++ b/src/compiler/prioritization/procedure.md
@@ -61,11 +61,11 @@ High level overview:
 
 Add `T-compiler` and `libs-impl` labels to corresponding issues that are missing these labels.
 
-- [No team assigned unprioritized I-prioritize](https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+-label%3AP-critical+-label%3AP-high+-label%3AP-medium+-label%3AP-low+label%3AI-prioritize+-label%3AT-compiler+-label%3Alibs-impl+-label%3AT-lang+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc)
-- [No team assigned stable nominations](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+-label%3AT-compiler+-label%3Alibs-impl+-label%3AT-lang+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc)
-- [No team assigned beta nominations](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+-label%3AT-compiler+-label%3Alibs-impl+-label%3AT-lang+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc)
-- [No team assigned I-nominated](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+-label%3AT-compiler+-label%3Alibs-impl+-label%3AT-lang+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc)
-- [No team assigned PR's waiting on team](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AS-waiting-on-team+-label%3AT-compiler+-label%3Alibs-impl+-label%3AT-lang+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc)
+- [No team assigned unprioritized I-prioritize](https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+-label%3AP-critical+-label%3AP-high+-label%3AP-medium+-label%3AP-low+label%3AI-prioritize+-label%3AT-compiler+-label%3AT-cargo+-label%3AT-core+-label%3AT-doc+-label%3AT-infra+-label%3AT-lang+-label%3AT-libs+-label%3Alibs-impl+-label%3AT-release+-label%3AT-rustdoc)
+- [No team assigned stable nominations](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+-label%3AT-compiler+-label%3AT-cargo+-label%3AT-core+-label%3AT-doc+-label%3AT-infra+-label%3AT-lang+-label%3AT-libs+-label%3Alibs-impl+-label%3AT-release+-label%3AT-rustdoc)
+- [No team assigned beta nominations](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+-label%3AT-compiler+-label%3AT-cargo+-label%3AT-core+-label%3AT-doc+-label%3AT-infra+-label%3AT-lang+-label%3AT-libs+-label%3Alibs-impl+-label%3AT-release+-label%3AT-rustdoc)
+- [No team assigned I-nominated](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+-label%3AT-compiler+-label%3AT-cargo+-label%3AT-core+-label%3AT-doc+-label%3AT-infra+-label%3AT-lang+-label%3AT-libs+-label%3Alibs-impl+-label%3AT-release+-label%3AT-rustdoc)
+- [No team assigned PR's waiting on team](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AS-waiting-on-team+-label%3AT-compiler+-label%3AT-cargo+-label%3AT-core+-label%3AT-doc+-label%3AT-infra+-label%3AT-lang+-label%3AT-libs+-label%3Alibs-impl+-label%3AT-release+-label%3AT-rustdoc)
 
 #### Assign priority to unprioritized issues with "I-prioritize" label
 


### PR DESCRIPTION
r? @XAMPPRocky 

cc @rust-lang/wg-prioritization 

This adds to the filters `T-doc`, `T-core` and `T-cargo`. I've just seen some issues popping up due to not filtering those teams.