### PR TITLE
Fix broken link to rust-lang/www.rust-lang.org good first issues

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -23,7 +23,7 @@ Repository                  | Description
 [gh/rust]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-help-wanted+no%3Aassignee
 [gh/cargo]: https://github.com/rust-lang/cargo/issues?q=is%3Aopen+is%3Aissue+label%3AE-help-wanted+no%3Aassignee
 [gh/crates.io]: https://github.com/rust-lang/crates.io/issues?q=is%3Aopen+is%3Aissue+label%3AE-help-wanted+no%3Aassignee
-[gh/www]: https://github.com/rust-lang/www.rust-lang.org/labels/good%20first%20issue+no%3Aassignee
+[gh/www]: https://github.com/rust-lang/www.rust-lang.org/issues?q=is%3Aopen+label%3A%22good+first+issue%22+no%3Aassignee
 
 ### Current Release Versions
 


### PR DESCRIPTION
Link on current master (shows 0 open, 0 closed):

https://github.com/rust-lang/www.rust-lang.org/labels/good%20first%20issue+no%3Aassignee

Link in this commit (shows 0 open, 24 closed):

https://github.com/rust-lang/www.rust-lang.org/issues?q=is:open+label:%22good+first+issue%22+no:assignee