### PR TITLE
Update the release process with Twitter instructions

### DIFF
--- a/src/release/process.md
+++ b/src/release/process.md
@@ -106,6 +106,11 @@ Send a PR to the master branch to:
 
 Decide on a time to do the release, T.
 
+- **T-50m** - Ensure there is someone with access to the `@rustlang` Twitter
+  account who'll be able to tweet as soon as we publish the blog post. [Steve
+  Klabnik](https://github.com/steveklabnik) usually manages the account, but
+  all Core Team members have access to it.
+
 - **T-50m** - Run the following command in a shell with [AWS
   credentials][awscli] in the [simpleinfra] repository:
 
@@ -133,7 +138,11 @@ Decide on a time to do the release, T.
 
 - **T** - Tweet and post everything!
 
-  - Twitter [@rustlang](https://twitter.com/rustlang)
+  - Twitter [@rustlang](https://twitter.com/rustlang). Optional template:
+
+    > Rust `$VERSION` has been released, featuring `$MAJOR_FEATURES`! 🎉 Check
+    > out the highlights on our blog: `$LINK`
+
   - Reddit [/r/rust](https://www.reddit.com/r/rust/)
   - [Hacker News](https://news.ycombinator.com/)
   - [Users forum](https://users.rust-lang.org/)

--- a/src/release/process.md
+++ b/src/release/process.md
@@ -106,7 +106,7 @@ Send a PR to the master branch to:
 
 Decide on a time to do the release, T.
 
-- **T-30m** - Run the following command in a shell with [AWS
+- **T-50m** - Run the following command in a shell with [AWS
   credentials][awscli] in the [simpleinfra] repository:
 
   ```
@@ -129,7 +129,7 @@ Decide on a time to do the release, T.
   After this [Update thanks.rust-lang.org][update-thanks] by triggering a build
   on GitHub Actions on the master branch.
 
-- **T-5m** - Merge blog post.
+- **T-2m** - Merge blog post.
 
 - **T** - Tweet and post everything!
 

--- a/src/release/process.md
+++ b/src/release/process.md
@@ -143,8 +143,6 @@ Decide on a time to do the release, T.
     > Rust `$VERSION` has been released, featuring `$MAJOR_FEATURES`! 🎉 Check
     > out the highlights on our blog: `$LINK`
 
-  - Reddit [/r/rust](https://www.reddit.com/r/rust/)
-  - [Hacker News](https://news.ycombinator.com/)
   - [Users forum](https://users.rust-lang.org/)
 
 - **T+5m** - Release and tag Cargo. In the rust-lang/rust repository on the


### PR DESCRIPTION
As we discussed during the last release team meeting, I talked with @steveklabnik on how to improve the way we tweet new releases to the world, and came up with the following changes to our release process:

* Added an item to ensure there is someone with Twitter access ready at the start of the release process.
* Added an optional tweet templates when someone doesn't want to come up with something from scratch.

I also did some tweaks to the `T-NN` to make them a bit more accurate.

r? @Mark-Simulacrum 
cc @rust-lang/release 