### PR TITLE
Mention stable backporting procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ documentation useful for members of [The Rust Programming Language].
 
 # Development
 
-You can build a local version by running the following command.
+You can build a local version by installing [mdbook] and running the following command.
 
 ```console
 mdbook build
@@ -17,6 +17,8 @@ mdbook build
 This will build and run the `blacksmith` tool automatically. When developing
 it's recommended to use the `serve` command to launch a local server to allow
 you to easily see and update changes you make.
+
+[mdbook]: https://github.com/rust-lang/mdBook
 
 ```console
 mdbook serve
@@ -59,7 +61,7 @@ Any Rust team can have a section in the Rust Forge. If you'd like to add your te
 ```
 
 If you run `mdbook build`, `mdbook` will automatically create the folder and file for your team.
- 
+
 It's recommended that you put general team information in `src/<TEAM_NAME>/README.md`, such as where the meetings happen, repositories that the team manages, links to chat platforms, etc. Larger topics should be made as a subpage, e.g. (`src/release/topic.md`).
 
 ```markdown

--- a/book.toml
+++ b/book.toml
@@ -15,7 +15,8 @@ no-section-label=true
 git-repository-url="https://github.com/rust-lang/rust-forge"
 
 [output.html.redirect]
-"beta-backporting.html" = "/release/beta-backporting.html"
+"beta-backporting.html" = "/release/backporting.html"
+"release/beta-backporting.html" = "/release/backporting.html"
 "bibliography.html" = "https://rustc-dev-guide.rust-lang.org/appendix/bibliography.html"
 "channel-layout.html" = "/infra/channel-layout.html"
 "debugging.html" = "https://rustc-dev-guide.rust-lang.org/compiler-debugging.html"

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -69,7 +69,7 @@
 - [Libs](./libs/README.md)
     - [Maintaining the standard library](./libs/maintaining-std.md)
 - [Release](./release/README.md)
-    - [Beta Backporting](./release/beta-backporting.md)
+    - [Backporting](./release/backporting.md)
     - [Preparing Release Notes](./release/release-notes.md)
     - [Release Process](./release/process.md)
     - [Rollup Procedure](./release/rollups.md)

--- a/src/release/backporting.md
+++ b/src/release/backporting.md
@@ -1,15 +1,14 @@
-# Beta Backporting
+# Backporting
 
-There's a steady trickle of patches that need to be ported to the beta branch.
-Only a few people are even aware of the process, but this is actually something
-anybody can do.
+There's a steady trickle of patches that need to be ported to the beta and stable branch.
+Only a few people are even aware of the process, but this is actually something anybody can do.
 
-## Backporting in `rust-lang/rust`
+## Beta backporting in `rust-lang/rust`
 
 When somebody identifies a PR that should be backported to beta they tag it
 [`beta-nominated`](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aclosed+label%3Abeta-nominated).
 That means they want one of the teams to evaluate whether the patch should be
-backported. I also suggest applying the `I-nominated` and and a `T-` (team) tag
+backported. It is also suggested applying the `I-nominated` and and a `T-` (team) tag
 as appropriate: that'll _really_ get their attention. Anybody with triage access
 is free to make these tags. Backports are mostly done to fix regressions. If the
 team thinks it should be backported they'll then additionally tag it
@@ -33,7 +32,21 @@ tag_ (people forget to do this a lot). This last step indicates that the
 backport has been completed, so the `beta-nominated` and `beta-accepted` tags
 have three states.
 
-## Backporting in `rust-lang/cargo`
+If, on the other hand, a backport is declined the `beta-nominated` label is
+removed, closing the procedure.
+
+## Stable backporting in `rust-lang/rust`
+
+Backports to the stable branch work exactly the same as beta ones, labels have
+just a slightly different name: `stable-nominated` identifies a PR to be
+discussed for a backport and `stable-accepted` is a PR accepted for
+backport. Declined stable nomination will have the `stable-nominated` label
+removed.
+
+The `T-release` will decide on a case by case basis if a stable backport will
+warrant a point (.patch) release (f.e. release a `1.50.1` between `1.50` and `1.51`).
+
+## Beta Backporting in `rust-lang/cargo`
 
 The procedure for backporting fixes to Cargo is similar but slightly more
 extended than the `rust-lang/rust` repo's procedure. Currently there aren't
@@ -57,4 +70,3 @@ member has approved the backport to happen you're good to start sending PRs!
 
 After that's all said and done the Cargo change is ready to get scheduled onto
 the beta release!
-


### PR DESCRIPTION
Hi,

I'm not sure where stable backports are explained, so I've tried rewording the backporting page adding them.

Since now the page is about generic backporting I've renamed the .md file and updated the index and the redirection for clients landing on `./release/beta-backporting.html`

Thanks for having a look at this!

r? @Mark-Simulacrum @XAMPPRocky 