### PR TITLE
Update the release process as of 1.52.0

### DIFF
--- a/src/release/process.md
+++ b/src/release/process.md
@@ -98,9 +98,25 @@ branch of rust-lang/rust which:
 
 Send a PR to the master branch to:
 
-- modify src/stage0.txt to bootstrap from yesterday's beta
-- Remove `cfg(stage0)` annotated items
-- Replace `cfg(not(stage0))` with nothing
+- Update `src/stage0.txt` to change `date` to "YYYY-MM-DD" where the date is
+  the archive date when the beta build was uploaded.
+
+- Remove references to the `bootstrap` and `not(bootstrap)` conditional
+  compilation attributes. You can find all of them by installing [ripgrep] and
+  running this command:
+
+  ```
+  rg '#!?\[.*\(bootstrap' -t rust
+  ```
+
+  The general guidelines (both for `#[]` and `#![]`) are:
+
+  - Remove any item annotated with `#[cfg(bootstrap)]`.
+  - Remove any `#[cfg(not(bootstrap))]` attribute while keeping the item.
+  - Remove any `#[cfg_attr(bootstrap, $attr)]` attribute while keeping the item.
+  - Replace any `#[cfg_attr(not(bootstrap), doc="$doc")]` with `$doc` in the
+    relevant documentation block (or in a new documentation block).
+  - Replace any `#[cfg_attr(not(bootstrap), $attr)]` with `#[$attr]`.
 
 ## Release day (Thursday)
 
@@ -196,3 +212,4 @@ RUSTUP_DIST_SERVER=https://dev-static.rust-lang.org rustup toolchain install nig
 [awscli]: /infra/docs/aws-access.md#using-the-aws-cli
 [rust-lang/rust]: https://github.com/rust-lang/rust
 [simpleinfra]: https://github.com/rust-lang/simpleinfra
+[ripgrep]: https://github.com/burntsushi/ripgrep

--- a/src/release/process.md
+++ b/src/release/process.md
@@ -106,7 +106,7 @@ Send a PR to the master branch to:
 
 Decide on a time to do the release, T.
 
-- **T-30m** - Run the following command in a shell with [AWS
+- **T-50m** - Run the following command in a shell with [AWS
   credentials][awscli] in the [simpleinfra] repository:
 
   ```
@@ -129,7 +129,7 @@ Decide on a time to do the release, T.
   After this [Update thanks.rust-lang.org][update-thanks] by triggering a build
   on GitHub Actions on the master branch.
 
-- **T-5m** - Merge blog post.
+- **T-2m** - Merge blog post.
 
 - **T** - Tweet and post everything!
 

--- a/src/release/process.md
+++ b/src/release/process.md
@@ -134,8 +134,6 @@ Decide on a time to do the release, T.
 - **T** - Tweet and post everything!
 
   - Twitter [@rustlang](https://twitter.com/rustlang)
-  - Reddit [/r/rust](https://www.reddit.com/r/rust/)
-  - [Hacker News](https://news.ycombinator.com/)
   - [Users forum](https://users.rust-lang.org/)
 
 - **T+5m** - Release and tag Cargo. In the rust-lang/rust repository on the


### PR DESCRIPTION
This PR includes miscellaneous updates to the release process to reflect what I'm doing for the 1.52.0 release. The changes are:

1. Update the `T-` in the release day schedule to better reflect how long `promote-release` takes nowadays.
2. Remove posting on Reddit and HN from the list of things to do after the release.
3. Expand the documentation on Wednesday's steps, better reflecting what I did this cycle and adding guidelines on what to do for `bootstrap` cfgs. The guidelines would've been really useful when I started doing releases, and I hope they'll be useful when we onboard new people to doing releases.

Notably, commits for (1) and (2) were already included and reviewed in https://github.com/rust-lang/rust-forge/pull/517. Once this is merged I'll rebase https://github.com/rust-lang/rust-forge/pull/517 to only include things were we don't have consensus yet.

r? @Mark-Simulacrum 