### PR TITLE
Change “Release Date” to “Will be stable on”.

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -35,8 +35,8 @@ Avoid changing the "Current Release Versions" without also updating the selector
 in `js/index.js`.
 -->
 
-Channel    | Version | Release Date
------------|---------|-------------
+Channel    | Version | Will be stable on
+-----------|---------|------------------
 Stable     | <span id="stable-version"></span>  | <span id="stable-release-date"></span>
 Beta       | <span id="beta-version"></span>    | <span id="beta-release-date"></span>
 Nightly    | <span id="nightly-version"></span> | <span id="nightly-release-date"></span>


### PR DESCRIPTION
I believe the current heading “Release Date” is hard to understand; the first obvious interpretation is “The version currently in this channel was released to this channel on…”, which is falsifiable since non-stable channel dates are in the future, but it's still a speedbump. I believe that relabeling it to “Will be stable on” will make the table easier to understand by newcomers.