### PR TITLE
fix typo in date format in /index.js

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -3,7 +3,7 @@
 // Rust 1.5.0 was released on 2015-12-10
 const EPOCH_DATE = moment.utc('2015-12-10')
 const EPOCH_RELEASE = 5
-const DATE_FORMAT = 'MMMM Do YYYY'
+const DATE_FORMAT = 'MMMM DD YYYY'
 const newReleases = Math.floor(moment.utc().diff(EPOCH_DATE, 'weeks') / 6)
 
 function addRelease (kind, incr, toolsWeek) {


### PR DESCRIPTION
this PR changes the date format string from "MM Do YYYY" (which was considered a typo) to "MM DD YYYY".

feel free to close this PR if that was not a typo.