### PR TITLE
fix typo, list subtrees in priority gudiance

### DIFF
--- a/src/compiler/reviews.md
+++ b/src/compiler/reviews.md
@@ -15,7 +15,7 @@ request review from someone else. This will also reassign the PR.
 
 We never merge PRs directly. Instead, we use bors. A qualified
 reviewer with bors privileges (e.g., a [compiler
-contributor](./membership.md) will leave a comment like `@bors r+`.
+contributor](./membership.md)) will leave a comment like `@bors r+`.
 This indicates that they approve the PR.
 
 People with bors privileges may also leave a `@bors r=username`
@@ -83,7 +83,7 @@ The following is some guidance for setting priorities:
     - P-high issue fixes
     - Toolstate fixes
     - Beta-nominated PRs
-    - Submodule updates
+    - Submodule/Subtree updates
 - 5+
     - P-critical issue fixes
 - 10+


### PR DESCRIPTION
Noticed the missing closing paren while reading, and also thought it would be good to mention subtrees alongside submodules given that multiple tools have switched from submods to subtrees.