### PR TITLE
Disable dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: cargo
-  directory: "/blacksmith"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10


### PR DESCRIPTION
The Dependabot version updates are generating a large number of PRs that currently aren't being merged.  This ends up generating a lot of noise for those watching this repository. Since keeping blacksmith dependencies up-to-date doesn't seem particularly important, this proposes to just disable it for now.
