### PR TITLE
say where the rust-timer bot command docs are

### DIFF
--- a/src/infra/service-infrastructure.md
+++ b/src/infra/service-infrastructure.md
@@ -82,6 +82,9 @@ necessary try-build and queue a perf run by saying
 (Technically, the requirement is that the `queue` command finishes executing prior
 to the try build completing successfully.)
 
+See the [documentation](https://github.com/rust-lang/rustc-perf/tree/master/collector#benchmarking)
+for further bot commands.
+
 [collector]: https://github.com/rust-lang-nursery/rustc-perf/tree/master/collector
 [web frontend + bot]: https://github.com/rust-lang-nursery/rustc-perf/tree/master/site
 


### PR DESCRIPTION
The document says there's a "[collector] and a [web frontend + bot]", but confusingly the bot docs are with the collector, so let's be a little more explicit.