### PR TITLE
Add branch date to index page

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -7,12 +7,14 @@ const DATE_FORMAT = 'MMMM DD YYYY'
 const newReleases = Math.floor(moment.utc().diff(EPOCH_DATE, 'weeks') / 6)
 
 function addRelease (kind, incr, toolsWeek) {
-  const releaseNumber = EPOCH_RELEASE + newReleases + incr
-  const displayVersion = `1.${releaseNumber}`
-  const releaseDate = EPOCH_DATE.clone().add((newReleases + incr) * 6, 'weeks')
+  const releaseNumber = EPOCH_RELEASE + newReleases + incr;
+  const displayVersion = `1.${releaseNumber}`;
+  const releaseDate = EPOCH_DATE.clone().add((newReleases + incr) * 6, 'weeks');
+  const branchDate = EPOCH_DATE.clone().add((newReleases + incr) * 6, 'weeks').subtract(6, 'days');
 
   document.querySelector(`#${kind}-version`).textContent = displayVersion
   document.querySelector(`#${kind}-release-date`).textContent = `${releaseDate.format(DATE_FORMAT)} UTC`
+  document.querySelector(`#${kind}-branch-date`).textContent = `${branchDate.format(DATE_FORMAT)} UTC`
 
   if (toolsWeek) {
     const noBreakagesTo = releaseDate.clone().subtract(6, 'weeks').day(2)

--- a/src/README.md
+++ b/src/README.md
@@ -9,7 +9,7 @@ file an issue or PR on the [Rust Forge GitHub].
 
 ### Help Wanted
 
-Want to contribute to Rust, but don't know where to start? Here's a list of 
+Want to contribute to Rust, but don't know where to start? Here's a list of
 `rust-lang` projects that have marked issues that need help and issues that are
 good first issues.
 
@@ -35,12 +35,15 @@ Avoid changing the "Current Release Versions" without also updating the selector
 in `js/index.js`.
 -->
 
-Channel    | Version | Will be stable on
------------|---------|------------------
-Stable     | <span id="stable-version"></span>  | <span id="stable-release-date"></span>
-Beta       | <span id="beta-version"></span>    | <span id="beta-release-date"></span>
-Nightly    | <span id="nightly-version"></span> | <span id="nightly-release-date"></span>
-Nightly +1 | <span id="next-version"></span>    | <span id="next-release-date"></span>
+Channel    | Version | Will be stable on | Will branch from master on |
+-----------|---------|-------------------|----------------------------|
+Stable     | <span id="stable-version"></span>  | <span id="stable-release-date"></span>  | <span id="stable-branch-date"></span>
+Beta       | <span id="beta-version"></span>    | <span id="beta-release-date"></span>    | <span id="beta-branch-date"></span>
+Nightly    | <span id="nightly-version"></span> | <span id="nightly-release-date"></span> | <span id="nightly-branch-date"></span>
+Nightly +1 | <span id="next-version"></span>    | <span id="next-release-date"></span>    | <span id="next-branch-date"></span>
+
+See the [release process](./release/process.md) documentation for details on
+what happens in the days leading up to a release.
 
 ### No Tools Breakage Week
 To ensure the beta release includes all the tools, no [tool breakages] are


### PR DESCRIPTION
This helps teams plan for when we're close to cut off points, rather than
planning around the stable date (which is important only for backports, really).