### PR TITLE
Update the release process for latest automation

### DIFF
--- a/src/release/process.md
+++ b/src/release/process.md
@@ -116,7 +116,7 @@ is merged, issue the following command in a shell with [AWS
 credentials][awscli] on the [simpleinfra] repository:
 
 ```
-./release-scripts/promote-release.py release dev stable --bypass--startup-checks
+./release-scripts/promote-release.py release dev stable --bypass-startup-checks
 ```
 
 You'll also want to update the previously published blog post and internals post


### PR DESCRIPTION
This assumes that https://github.com/rust-lang/promote-release/pull/46 and https://github.com/rust-lang/promote-release/pull/45 have been merged and a few scripts updated/added in the simpleinfra repository to account for them. (Should be pretty easy to do, but is a little bit of work).

r? @pietroalbini 