### PR TITLE
Changes reflecting the new placeholder system for stabilizations

### DIFF
--- a/src/release/backporting.md
+++ b/src/release/backporting.md
@@ -22,6 +22,7 @@ Getting a PR backported to the beta branch involves the following process:
    1. Create a local branch off the `beta` branch.
    2. Cherry-pick all of the PRs that have both [`beta-nominated` and `beta-accepted`][nominated-plus-accepted] labels.
       It is usually preferred to not include PRs that have not been merged in case there are any last minute changes, or it fails when running the full CI tests.
+   3. Run `./x.py run replace-version-placeholder` and if there were any changes, put them into a new commit.
    3. (Recommended) Run some tests locally.
       It is not uncommon that the backports may not apply cleanly, or the UI tests need to be re-blessed if there are differences in the output.
    4. Open a PR **against the beta branch** with a title that starts with `[beta]` (so reviewers can see its specialness).

--- a/src/release/process.md
+++ b/src/release/process.md
@@ -25,7 +25,13 @@ time, but make sure the stable promotion lands first.
 ```
 
 Once that's done, send a PR to the freshly created beta branch of rust-lang/rust
-which updates `src/ci/channel` to `beta`.
+with two commits:
+
+* The changes caused by running `./x.py run replace-version-placeholder`
+* An update of `src/ci/channel` to `beta`
+
+The version placeholder replacement changes must be in a separate commit so
+that they can be cherry picked to the master branch.
 
 Also send a PR to rust-lang/rust targeting the new stable branch making the
 following changes:
@@ -49,6 +55,10 @@ credentials][awscli] and run this command from the [simpleinfra] repository:
 
 Send a PR to the master branch to:
 
+- Cherry pick the commit that ran `./x.py run replace-version-placeholder`
+  from the now merged beta branch PR. Do not re-run the tool as there might
+  have been other stabilizations on master which were not included in the
+  branched beta, so may not be attributed to the current release.
 - Run `./x.py run src/tools/bump-stage0` to update the bootstrap compiler to
   the beta you created yesterday.
 


### PR DESCRIPTION
Due to https://github.com/rust-lang/rust/pull/100591

There are a few changes in the release process and how changes are backported to beta, mostly around running `./x.py run replace-version-placeholder` at specific points. This PR updates the document so that it is followed for future releases.