### PR TITLE
Update for highfive transition

### DIFF
--- a/src/compiler/membership.md
+++ b/src/compiler/membership.md
@@ -60,7 +60,7 @@ Being promoted to contributor implies a number of privileges:
   
 It also implies some obligations (in some cases, optional obligations):
 
-- Contributors will be asked if they wish to be added to highfive rotation.
+- Contributors will be asked if they wish to be added to the reviewer rotation.
 - Contributors are held to a higher standard than ordinary folk when
   it comes to the [Code of Conduct][CoC].
 

--- a/src/compiler/reviews.md
+++ b/src/compiler/reviews.md
@@ -5,7 +5,7 @@ reviewed by at least one person who is knowledgeable with the code in
 question.
 
 When a PR is opened, you can request a reviewer by including `r?
-@username` in the PR description. If you don't do so, the highfive bot
+@username` in the PR description. If you don't do so, rustbot
 will automatically assign someone.
 
 It is common to leave a `r? @username` comment at some later point to

--- a/src/infra/service-infrastructure.md
+++ b/src/infra/service-infrastructure.md
@@ -19,6 +19,9 @@ your own work, please let the infrastructure team know.
 ([bot user account](https://github.com/rust-highfive)) which welcomes newcomers
 and assigns reviewers.
 
+> **Note**: Highfive is currently being replaced by [rustbot](#rustbot). This
+> service will be shut down in the future once the migration is complete.
+
 ## Rust Log Analyzer
 
 The [Rust Log Analyzer](https://github.com/rust-lang/rust-log-analyzer)

--- a/src/infra/team-maintenance.md
+++ b/src/infra/team-maintenance.md
@@ -32,9 +32,9 @@ To make a full team member, the following places need to be modified:
   [rust-lang-nursery/TEAM][gh-nursery-team] teams on github must be updated
 - the
   [internals discussion board has per-team groups](https://internals.rust-lang.org/admin/groups/custom)
-- the list of reviewers highfive uses is set in [rust-lang/highfive][highfive]
-  - the configs are set per-repo; some teams are listed in `rust.json`, whereas
-    those that span multiple repos are set in `_global.json`
+- if the member is going to join the review rotation, they will need to be
+  added to the `[assign.owners]` section of `triagebot.toml` of the repos
+  where they will be reviewing
 
 ### Team member departure
 
@@ -45,6 +45,7 @@ Remove the team member from any and all places:
 - The [GitHub team][gh-team], [GitHub nursery team][gh-nursery-team]
 - [team repo]
 - [toolstate notifications]
+- `triagebot.toml` files of all repos they were involved in
 
 [gh-team]: https://github.com/orgs/rust-lang/teams
 [gh-nursery-team]: https://github.com/orgs/rust-lang-nursery/teams

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -20,11 +20,11 @@ If you spot anything that is outdated, under specified, missing, or just plain i
 
 ## If you’re ever unsure…
 
-Maintaining the standard library can feel like a daunting responsibility! Through [`highfive`], the automated reviewer assignment, you’ll find yourself dropped into a lot of new contexts.
+Maintaining the standard library can feel like a daunting responsibility! Through automated reviewer assignment via [`triagebot`][assignment], you’ll find yourself dropped into a lot of new contexts.
 
 Ping the `@rust-lang/libs` team on GitHub anytime. We’re all here to help!
 
-If you don’t think you’re the best person to review a PR then use [`highfive`] to assign it to somebody else.
+If you don’t think you’re the best person to review a PR then use [`triagebot`][assignment] to assign it to somebody else.
 
 ## Finding reviews waiting for your input
 
@@ -345,7 +345,7 @@ To try reduce noise in the docs from deprecated items, they should be moved to t
 [`rust-lang/rust-forge`]: https://github.com/rust-lang/rust-forge
 [`rfcbot`]: https://github.com/rust-lang/rfcbot-rs
 [`bors`]: https://github.com/rust-lang/homu
-[`highfive`]: https://github.com/rust-lang/highfive
+[assignment]: https://github.com/rust-lang/triagebot/wiki/Assignment
 [`crater`]: https://github.com/rust-lang/crater
 [`rust-timer`]: https://github.com/rust-lang-nursery/rustc-perf
 [Libs tracking issues]: https://github.com/rust-lang/rust/issues?q=label%3AC-tracking-issue+label%3AT-libs

--- a/src/release/rollups.md
+++ b/src/release/rollups.md
@@ -30,8 +30,8 @@ queue has been merged.
     @bors r+ rollup=never p=<NUMBER_OF_PRS_IN_ROLLUP>
     ````
 
-3. If the rollup fails, use the logs rust-highfive (really it is
-   rust-log-analyzer) provides to bisect the failure to a specific PR and do
+3. If the rollup fails, use the logs rust-log-analyzer
+   provides to bisect the failure to a specific PR and do
    `@bors r-`. If the PR is running, you need to do `@bors r- retry`. Otherwise,
    your rollup succeeded. If it did, proceed to the next rollup (every now and
    then let `rollup=never` and toolstate PRs progress).
@@ -57,7 +57,7 @@ This is something you will learn to improve over time. Some basic tips include
 ## Failed rollups
 If the rollup has failed, run the `@bors retry` command if the
 failure was spurious (e.g. due to a network problem or a timeout). If it wasn't spurious,
-find the offending PR and throw it out by copying a link to the rust-highfive comment,
+find the offending PR and throw it out by copying a link to the rust-logs-analyzer comment,
 and writing `Failed in <link_to_comment>, @bors r-`. Hopefully,
 the author or reviewer will give feedback to get the PR fixed or confirm that it's not
 at fault. The failed rollup PR can be closed.

--- a/src/release/triage-procedure.md
+++ b/src/release/triage-procedure.md
@@ -28,7 +28,7 @@
   communicates that the PR is an experiment to test out some changes.
 
 Also: [PRs with no status tags][no-status-tags]. This is useful to find PRs
-where highfive conked out and didn't assign a reviewer and thus didn't assign
+where rustbot conked out and didn't assign a reviewer and thus didn't assign
 [S-waiting-on-review]. These PRs can get lost otherwise. (Note that you should
 likely **not** triage PRs that have `r? @ghost` since that means the author does
 not need a review yet.)


### PR DESCRIPTION
As of https://github.com/rust-lang/triagebot/pull/1656, triagebot is replacing highfive. This PR updates the documentation to accommodate this change.
