### PR TITLE
Fix mdbook deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,16 +15,23 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@v2
-      - uses: XAMPPRocky/deploy-mdbook@v1.1
+      - uses: actions/checkout@v3
+      - name: Install mdbook
+        run: curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.22/mdbook-v0.4.22-x86_64-unknown-linux-gnu.tar.gz | tar -xz
+      - name: Build book
+        run: ./mdbook build
+      - name: Deploy book
+        uses: rust-lang/simpleinfra/github-actions/static-websites@master
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          build_only: ${{ github.ref != 'refs/heads/master' }}
+          deploy_dir: book
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+        if: github.ref == 'refs/heads/master'
       - name: Configure AWS credentials
         if: github.ref == 'refs/heads/master'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: arn:aws:iam::890664054962:role/forge-rust-lang-org-ci
           aws-region: us-east-1
-      - run: aws cloudfront create-invalidation --distribution-id E12A3GKHZSREHP --paths "/*"
+      - name: Invalidate CloudFront cache
+        run: aws cloudfront create-invalidation --distribution-id E12A3GKHZSREHP --paths "/*"
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
This fixes the CI build. The previous action was failing because it was trying to install the aarch64 binaries. This switches to a slightly simpler setup that just downloads mdbook and uses `simpleinfra/github-actions/static-websites` to deploy to gh-pages instead.

Closes #664
