### PR TITLE
Finalize highfive removal

### DIFF
--- a/src/infra/service-infrastructure.md
+++ b/src/infra/service-infrastructure.md
@@ -19,8 +19,7 @@ your own work, please let the infrastructure team know.
 ([bot user account](https://github.com/rust-highfive)) which welcomes newcomers
 and assigns reviewers.
 
-> **Note**: Highfive is currently being replaced by [rustbot](#rustbot). This
-> service will be shut down in the future once the migration is complete.
+> **Note**: Highfive has been replaced by [rustbot](#rustbot).
 
 ## Rust Log Analyzer
 

--- a/src/infra/team-maintenance.md
+++ b/src/infra/team-maintenance.md
@@ -40,7 +40,6 @@ To make a full team member, the following places need to be modified:
 
 Remove the team member from any and all places:
 
-- [highfive]
 - 1password
 - The [GitHub team][gh-team], [GitHub nursery team][gh-nursery-team]
 - [team repo]
@@ -49,7 +48,6 @@ Remove the team member from any and all places:
 
 [gh-team]: https://github.com/orgs/rust-lang/teams
 [gh-nursery-team]: https://github.com/orgs/rust-lang-nursery/teams
-[highfive]: https://github.com/rust-lang/highfive/tree/master/highfive/configs
 [team repo]: https://github.com/rust-lang/team/tree/master/teams
 [team website]: https://www.rust-lang.org/governance
 [toolstate notifications]: https://github.com/rust-lang/rust/blob/master/src/tools/publish_toolstate.py

--- a/src/platforms/zulip/triagebot.md
+++ b/src/platforms/zulip/triagebot.md
@@ -23,7 +23,8 @@ You can drop your claim to the issue via `@rustbot release-assignment`; Rust tea
 
 `@rustbot assign @user` can be used only by Rust team members and will assign that user to the issue (with same rules as before -- either directly or indirectly).
 
-Soon (when the "highfive" bot migration will be complete, see [rust-lang/highfive#258](https://github.com/rust-lang/highfive/pull/258)), `r?` will also assign reviewers to PRs, though unlike issues, non-team members cannot be assigned. Anyone can invoke the command.
+Triagebot also handles `r?` assignment for reviewers on PRs.
+See the [Assignment](https://github.com/rust-lang/triagebot/wiki/Assignment) documentation for more details.
 
 To enable on a repository, add the following to a `triagebot.toml` file in the repository root.
 


### PR DESCRIPTION
Now that highfive should no longer be used, this updates the docs to indicate its retirement.
