### PR TITLE
Remove mentions of highfive.

### DIFF
--- a/src/infra/service-infrastructure.md
+++ b/src/infra/service-infrastructure.md
@@ -13,15 +13,6 @@ your own work, please let the infrastructure team know.
 
 [rust-central-station]: https://github.com/rust-lang/rust-central-station
 
-## Highfive
-
-[Highfive](https://github.com/rust-lang/highfive) is a bot
-([bot user account](https://github.com/rust-highfive)) which welcomes newcomers
-and assigns reviewers.
-
-> **Note**: Highfive is currently being replaced by [rustbot](#rustbot). This
-> service will be shut down in the future once the migration is complete.
-
 ## Rust Log Analyzer
 
 The [Rust Log Analyzer](https://github.com/rust-lang/rust-log-analyzer)
@@ -138,5 +129,11 @@ Tracker](https://alexcrichton.github.io/rust-ci-timing-tracker/) tracks and
 compares how long CI jobs take over time. It is run by [Alex
 Crichton](https://github.com/alexcrichton/rust-ci-timing-tracker).
 
-[crates.io]: https://crates.io/
+## Highfive (retired)
 
+[Highfive](https://github.com/rust-lang/highfive) is a bot
+([bot user account](https://github.com/rust-highfive)) which was previously
+used to welcome newcomers and assigned reviewers. This service has been
+replaced with [rustbot](#rustbot).
+
+[crates.io]: https://crates.io/

--- a/src/infra/team-maintenance.md
+++ b/src/infra/team-maintenance.md
@@ -40,7 +40,6 @@ To make a full team member, the following places need to be modified:
 
 Remove the team member from any and all places:
 
-- [highfive]
 - 1password
 - The [GitHub team][gh-team], [GitHub nursery team][gh-nursery-team]
 - [team repo]
@@ -49,7 +48,6 @@ Remove the team member from any and all places:
 
 [gh-team]: https://github.com/orgs/rust-lang/teams
 [gh-nursery-team]: https://github.com/orgs/rust-lang-nursery/teams
-[highfive]: https://github.com/rust-lang/highfive/tree/master/highfive/configs
 [team repo]: https://github.com/rust-lang/team/tree/master/teams
 [team website]: https://www.rust-lang.org/governance
 [toolstate notifications]: https://github.com/rust-lang/rust/blob/master/src/tools/publish_toolstate.py

--- a/src/platforms/zulip/triagebot.md
+++ b/src/platforms/zulip/triagebot.md
@@ -23,7 +23,8 @@ You can drop your claim to the issue via `@rustbot release-assignment`; Rust tea
 
 `@rustbot assign @user` can be used only by Rust team members and will assign that user to the issue (with same rules as before -- either directly or indirectly).
 
-Soon (when the "highfive" bot migration will be complete, see [rust-lang/highfive#258](https://github.com/rust-lang/highfive/pull/258)), `r?` will also assign reviewers to PRs, though unlike issues, non-team members cannot be assigned. Anyone can invoke the command.
+The assignment handler also handles automatic assignment of PR reviewers and for the `r?` command to reassign reviewers.
+See [the Assignment documentation](https://github.com/rust-lang/triagebot/wiki/Assignment) for more details.
 
 To enable on a repository, add the following to a `triagebot.toml` file in the repository root.
 


### PR DESCRIPTION
Highfive has been shut down and archived, so I don't think this documentation is needed anymore.