### PR TITLE
update installation methods to use TLS v1.2

### DIFF
--- a/src/docs-rs/self-hosting.md
+++ b/src/docs-rs/self-hosting.md
@@ -20,7 +20,7 @@ Docs.rs has a few basic requirements:
 * LXC tools (doc builds run inside an LXC container)
 
 ```console
-$ curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly
+$ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
 $ source $HOME/.cargo/env
 # apt install build-essential git curl cmake gcc g++ pkg-config libmagic-dev libssl-dev zlib1g-dev postgresql lxc-utils
 ```
@@ -109,7 +109,7 @@ Inside the container, we also need to set up a `cratesfyi` user, and install Rus
 
 ```console
 lxc-attach -n cratesfyi-container -- adduser --disabled-login --disabled-password --gecos "" cratesfyi
-lxc-attach -n cratesfyi-container -- su - cratesfyi -c 'curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly'
+lxc-attach -n cratesfyi-container -- su - cratesfyi -c 'curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly'
 lxc-attach -n cratesfyi-container -- su - cratesfyi -c 'rustup target add i686-apple-darwin'
 lxc-attach -n cratesfyi-container -- su - cratesfyi -c 'rustup target add i686-pc-windows-msvc'
 lxc-attach -n cratesfyi-container -- su - cratesfyi -c 'rustup target add i686-unknown-linux-gnu'

--- a/src/infra/other-installation-methods.md
+++ b/src/infra/other-installation-methods.md
@@ -51,7 +51,7 @@ itself. Such targets can be installed with the `rustup target add` command.
 
 The way to install `rustup` differs by platform:
 
-- On Unix, run `curl https://sh.rustup.rs -sSf | sh` in your shell. This
+- On Unix, run `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh` in your shell. This
   downloads and runs [`rustup-init.sh`], which in turn downloads and runs the
   correct version of the `rustup-init` executable for your platform.
 - On Windows, download and run [`rustup-init.exe`].
@@ -62,7 +62,7 @@ script. Pass `--help` to `rustup-init` as follows to display the arguments
 `rustup-init` accepts:
 
 ```
-curl https://sh.rustup.rs -sSf | sh -s -- --help
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --help
 ```
 
 If you prefer not to use the shell script, you may directly download


### PR DESCRIPTION
Update other installation methods for Unix compatible OSes to use TLS v1.2 consistently with https://github.com/rust-lang/rustup/blob/843459f893091f89b2dd5c7a977da1b3eb28df1b/www/index.html#L31

See https://github.com/rust-lang/www.rust-lang.org/pull/1823#issuecomment-1595868324 for more information on why it is useful. TLDR: this allows to avoid MITM attacks when users are installing Rust using `rustup-init.sh`.

See similar PR to rustup repo: https://github.com/rust-lang/rustup/pull/3385

Closes https://github.com/rust-lang/rust-forge/issues/684