### PR TITLE
Add triagebot config.

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,0 +1,30 @@
+[relabel]
+
+[autolabel."S-waiting-on-review"]
+new_pr = true
+
+[shortcut]
+
+[assign]
+warn_non_default_branch = true
+
+[assign.adhoc_groups]
+fallback = [
+    "@Mark-Simulacrum",
+    "@ehuss",
+]
+
+[assign.owners]
+"/blacksmith" = ["@ehuss"]
+"/js" = ["@ehuss"]
+"/src/community" = ["community"]
+"/src/compiler" = ["compiler", "compiler-contributors"]
+"/src/crates-io" = ["crates-io"]
+"/src/docs-rs" = ["docs-rs"]
+"/src/governance" = ["ehuss"]
+"/src/infra" = ["infra"]
+"/src/lang" = ["lang"]
+"/src/libs" = ["libs"]
+"/src/platforms" = ["infra"]
+"/src/release" = ["release"]
+"/src/triagebot" = ["triagebot"]


### PR DESCRIPTION
This adds a triagebot configuration, primarily to set up auto-assignment and to support `r?`. I do not intend that the assignment is correct, since I suspect most of these teams would prefer some subset. However, I don't particularly want to hunt down every team to make a decision, so my intent is that the teams can post PRs to update the assignment to whoever they want (or just use manual `r?`).
