### PR TITLE
Propose rules for team repo maintenance

### DIFF
--- a/src/infra/team-maintenance.md
+++ b/src/infra/team-maintenance.md
@@ -14,7 +14,7 @@ systems integrated with it.
 
 # Rules for changes to team repo
 
-Pull requests to the repository are merged by the [team-admins], who use these rules to merge PRs:
+Pull requests to the repository are merged by the [team-repo-admins], who use these rules to merge PRs:
 
 ### `people`, `teams`, and `repos` directories
 
@@ -32,7 +32,7 @@ approve the change. Any team lead in the "parent team" chain may do so. This inc
 * Changing other metadata (website descriptions, Zulip groups, etc.)
 * Changing access to repositories owned by their team
   * For repositories ownership is not currently formally tracked. Until that is
-    added, the team-admins are expected to exercise their understanding of
+    added, the team-repo-admins are expected to exercise their understanding of
     which team owns the repository, when in doubt asking for clarification and
     codifying in a comment in the relevant repository.
 
@@ -42,7 +42,7 @@ The team repository additionally contains code to transform and validate the
 TOML user-edited files. This is owned by the Infrastructure team and approval
 should be sought for changes.
 
-### Who belongs to team-admins?
+### Who belongs to team-repo-admins?
 
 This group of people is nominated & approved by the Leadership Council, but is
 not selected through any formal criteria. Eventually, we hope that the need for
@@ -52,7 +52,7 @@ the above policies.
 Note also that the [infra-admins] team maintains "root" credentials to Rust
 infrastructure, including the team repo, in order to make changes if needed to
 keep infrastructure operational. Those rights should only be exercised when
-required though, with team-admins being the first point of contact for changes.
+required though, with team-repo-admins being the first point of contact for changes.
 (There may be overlap between the two teams).
 
 # Extra steps for changes
@@ -78,4 +78,4 @@ Remove the team member from any and all places:
 [gh-nursery-team]: https://github.com/orgs/rust-lang-nursery/teams
 [team repo]: https://github.com/rust-lang/team/tree/master/teams
 [team website]: https://www.rust-lang.org/governance
-[team-admins]: TODO
+[team-repo-admins]: TODO

--- a/src/infra/team-maintenance.md
+++ b/src/infra/team-maintenance.md
@@ -4,34 +4,64 @@ The roster of the Rust teams is always in flux. From time to time, new people
 are added, but also people sometimes opt to into "alumni status", meaning that
 they are not currently an active part of the decision-making process.
 Unfortunately, whenever a new person is added or someone goes into alumni
-status, there are a number of disparate places that need to be updated. This
-page aims to document that list. If you have any questions, or need someone with
-more privileges to make a change for you, a good place to ask is `#infra` on
-Discord.
+status, there are a number of disparate places that need to be updated.
 
-### Team repo
+# Team repo
 
 Membership of teams is primarily driven by the config files in the
-[rust-lang/team repo][team repo]. Several systems use the team repo data to
-control access:
+[rust-lang/team repo][team repo]. See the README of that respository for the
+systems integrated with it.
 
-- the [team website]
-- bors r+ rights
-- rfcbot interaction
-- Mailgun email lists
+# Rules for changes to team repo
 
-Team membership is duplicated in a few other places listed below, but the
-long-term goal is to centralize on the team repo.
+Pull requests to the repository are merged by the [team-admins], who use these rules to merge PRs:
+
+### `people`, `teams`, and `repos` directories
+
+If a change is related to an individual and does not expand permissions, then only the individual's approval is required. If the change has already been made outside of the team repo (e.g., GitHub username change) then it is considered implicitly approved. This non-exhaustively includes:
+
+* Changing team membership to alumni or full removal
+* Changing email address
+* Adding zulip-id
+
+If a change will grant additional permissions, then a team lead needs to
+approve the change. Any team lead in the "parent team" chain may do so. This includes:
+
+* Adding new subteams under an existing team
+* Granting additional access (bors, dev-desktop access, etc.)
+* Changing other metadata (website descriptions, Zulip groups, etc.)
+* Changing access to repositories owned by their team
+  * For repositories ownership is not currently formally tracked. Until that is
+    added, the team-admins are expected to exercise their understanding of
+    which team owns the repository, when in doubt asking for clarification and
+    codifying in a comment in the relevant repository.
+
+### Source code changes
+
+The team repository additionally contains code to transform and validate the
+TOML user-edited files. This is owned by the Infrastructure team and approval
+should be sought for changes.
+
+### Who belongs to team-admins?
+
+This group of people is nominated & approved by the Leadership Council, but is
+not selected through any formal criteria. Eventually, we hope that the need for
+this group to exist will diminish as additional automation is added to enforce
+the above policies.
+
+Note also that the [infra-admins] team maintains "root" credentials to Rust
+infrastructure, including the team repo, in order to make changes if needed to
+keep infrastructure opertaional. Those rights should only be exercised when
+required though, with team-admins being the first point of contact for changes.
+(There may be overlap between the two teams).
+
+# Extra steps for changes
 
 ### Full team membership
 
 To make a full team member, the following places need to be modified:
 
 - the [team repo]
-- the [rust-lang/TEAM][gh-team] and (in some cases)
-  [rust-lang-nursery/TEAM][gh-nursery-team] teams on github must be updated
-- the
-  [internals discussion board has per-team groups](https://internals.rust-lang.org/admin/groups/custom)
 - if the member is going to join the review rotation, they will need to be
   added to the `[assign.owners]` section of `triagebot.toml` of the repos
   where they will be reviewing
@@ -40,14 +70,12 @@ To make a full team member, the following places need to be modified:
 
 Remove the team member from any and all places:
 
-- 1password
-- The [GitHub team][gh-team], [GitHub nursery team][gh-nursery-team]
 - [team repo]
-- [toolstate notifications]
 - `triagebot.toml` files of all repos they were involved in
+- 1password
 
 [gh-team]: https://github.com/orgs/rust-lang/teams
 [gh-nursery-team]: https://github.com/orgs/rust-lang-nursery/teams
 [team repo]: https://github.com/rust-lang/team/tree/master/teams
 [team website]: https://www.rust-lang.org/governance
-[toolstate notifications]: https://github.com/rust-lang/rust/blob/master/src/tools/publish_toolstate.py
+[team-admins]: TODO

--- a/src/infra/team-maintenance.md
+++ b/src/infra/team-maintenance.md
@@ -51,7 +51,7 @@ the above policies.
 
 Note also that the [infra-admins] team maintains "root" credentials to Rust
 infrastructure, including the team repo, in order to make changes if needed to
-keep infrastructure opertaional. Those rights should only be exercised when
+keep infrastructure operational. Those rights should only be exercised when
 required though, with team-admins being the first point of contact for changes.
 (There may be overlap between the two teams).
 

--- a/src/infra/team-maintenance.md
+++ b/src/infra/team-maintenance.md
@@ -78,4 +78,5 @@ Remove the team member from any and all places:
 [gh-nursery-team]: https://github.com/orgs/rust-lang-nursery/teams
 [team repo]: https://github.com/rust-lang/team/tree/master/teams
 [team website]: https://www.rust-lang.org/governance
-[team-repo-admins]: TODO
+[team-repo-admins]: https://github.com/rust-lang/team/blob/master/teams/team-repo-admins.toml
+[infra-admins]: https://github.com/rust-lang/team/blob/master/teams/infra-admins.toml


### PR DESCRIPTION
Per leadership council discussion in our last meeting, proposing a set of rules for us to approve on behalf of the project with regards to team repo administration. The goal is to largely codify the status quo, while providing opportunity for expansion of merge rights under documented guidelines.

cc @jackh726