### PR TITLE
Try to formalize the "concern" syntax for MCPs

### DIFF
--- a/src/compiler/mcp.md
+++ b/src/compiler/mcp.md
@@ -133,7 +133,19 @@ The compiler-team repo issues are intended to be low traffic and used for proced
 
 ## How does one register as reviewer, register approval, or raise an objection?
 
-These types of procedural comments can be left on the issue (it's also good to leave a message in Zulip). See the previous section.
+These types of procedural comments can be left on the issue (it's also good to leave a message in Zulip). See the
+previous section. To facilitate a machine parsable scanning of the concerns please use the following syntax to formally
+register a concern:
+```
+@rustbot concern reason-for-concern
+
+<long description of the concern>
+```
+
+And the following syntax to lift a concern when resolved:
+```
+@rustbot resolve reason-for-concern
+```
 
 ## Who decides whether a concern is unresolved?
 


### PR DESCRIPTION
Sibling PR to https://github.com/rust-lang/triagebot/pull/1747

Context: I'm trying to encourage a homogenous syntax to raise and resolve concerns in MCPs, so it'll be easier to parse the github comments and summarize the consensus status of the MCP.

As mentioned in the other PR, the suggested syntax mimics the FCP but will not activate anything nor will emit errors. It's just formalizing a syntax.
[
Rendered](https://github.com/rust-lang/rust-forge/blob/70f9c722d656588210c582170dc1dfd17e6cac2c/src/compiler/mcp.md#how-does-one-register-as-reviewer-register-approval-or-raise-an-objection)

cc: @Mark-Simulacrum for a :+1: 