### PR TITLE
Add information about calendar automation

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -9,6 +9,7 @@
   - [Zulip](./platforms/zulip.md)
       - [Moderation](./platforms/zulip/moderation.md)
   - [Blogs](./platforms/blogs.md)
+  - [Calendars](./platforms/calendars.md)
 - [Triagebot](./triagebot/README.md)
     - [Agenda Generator](./triagebot/agenda.md)
     - [Issue Assignment](./triagebot/issue-assignment.md)

--- a/src/platforms/calendars.md
+++ b/src/platforms/calendars.md
@@ -1,0 +1,13 @@
+# Calendars
+
+Many Rust teams and working groups have regular meetings, and it can get
+challenging quickly to manage all the calendar events.
+
+That's why we have automation available for generating both one-time
+and recurring calendar events. It can be found in the
+[calendar](https://github.com/rust-lang/calendar) repository, which also
+contains a guide for its usage.
+
+You can use it to create and update calendar invites using declaratively
+using a TOML file, and the tool will then generate `.ics` files from them,
+which can be imported into various calendar tools.


### PR DESCRIPTION
Adds a short info about the new calendar automation. I wasn't sure where best to put it, but I think that `Platforms` is a good fit.