### PR TITLE
Fix typo in calendars.md

### DIFF
--- a/src/platforms/calendars.md
+++ b/src/platforms/calendars.md
@@ -8,6 +8,6 @@ and recurring calendar events. It can be found in the
 [calendar](https://github.com/rust-lang/calendar) repository, which also
 contains a guide for its usage.
 
-You can use it to create and update calendar invites using declaratively
+You can use it to create and update calendar invites declaratively
 using a TOML file, and the tool will then generate `.ics` files from them,
 which can be imported into various calendar tools.


### PR DESCRIPTION
Typo that I noticed immediately after https://github.com/rust-lang/rust-forge/pull/723 was merged :facepalm: