### PR TITLE
Add docs for tracking PRs assigned for review through the Zulip chat

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -14,6 +14,7 @@
     - [Agenda Generator](./triagebot/agenda.md)
     - [Issue Assignment](./triagebot/issue-assignment.md)
     - [PR Assignment](./triagebot/pr-assignment.md)
+    - [Tracking PR assignment](./triagebot/pr-assignment-tracking.md)
     - [Autolabels](./triagebot/autolabels.md)
     - [Close](./triagebot/close.md)
     - [Documentation Updates](./triagebot/doc-updates.md)

--- a/src/triagebot/pr-assignment-tracking.md
+++ b/src/triagebot/pr-assignment-tracking.md
@@ -1,0 +1,24 @@
+# Tracking PR assignment
+
+If you contribute in some capacity to the Rust compiler development, you might also be assigned pull requests to be reviewed.
+
+You can check your current review assignment in two ways:
+- by visiting this [GitHub URL](https://github.com/pulls/assigned)
+- by interacting with the `triagebot` on the [Zulip chat](/platforms/zulip.md) in a DM (Direct Messages) thread. You can open a direct message session with the `triagebot` clicking on [this link](https://rust-lang.zulipchat.com/#narrow/dm/261224-triagebot) (requires Zulip login).
+
+This chapter will describe how to interact with the `triagebot` on Zulip.
+
+## Configuration
+
+Tracking the PR assignment is enabled on the git repository by having a `[pr-tracking]` table in `triagebot.toml`. No additional configuration is needed.
+
+## Usage
+
+Open a Direct Message session with the `triagebot` and send a message with one of these commands:
+
+* `work` --- Will emit an error and show the available commands
+* `work show` --- Will show your Github username and a list of pull requests assigned to you for review (on the `rust-lang/rust` git repository)
+
+## Implementation
+
+See [`parser/src/handlers/pr_tracking.rs`](https://github.com/rust-lang/triagebot/blob/HEAD/parser/handlers/pr_tracking.rs).

--- a/src/triagebot/pr-assignment.md
+++ b/src/triagebot/pr-assignment.md
@@ -3,6 +3,8 @@
 Triagebot handles automatic and manual assignment of GitHub PRs.
 It also handles welcoming new users when they post a PR.
 
+Rust contributors can track and manage their own work queue using the Zulipchat integration. See [Tracking PR assignment](/triagebot/pr-assignment-tracking.md).
+
 ## Usage
 
 Automatic assignment of new PRs is handled by the configuration in the `triagebot.toml`, described [below](#configuration).


### PR DESCRIPTION
We are implementing a mechanism to track and manage pull requests assigned for review to Rust contributors.

For now, the only interface to query your work queue is the Zulip chat.

This patch starts documenting how to interact with the Zulip chat bot.