### PR TITLE
Add Archive of Rust Stable Standalone Installers

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -68,6 +68,7 @@
     - [Moderation](./governance/moderation.md)
 - [Infrastructure](./infra/README.md)
     - [Other Installation Methods](./infra/other-installation-methods.md)
+    - [Archive of Rust Stable Standalone Installers](./infra/archive-stable-version-installers.md)
     - [Release Channel Layout](./infra/channel-layout.md)
     - [Service Infrastructure](./infra/service-infrastructure.md)
     - [Team Maintenance](./infra/team-maintenance.md)

--- a/src/infra/archive-stable-version-installers.md
+++ b/src/infra/archive-stable-version-installers.md
@@ -1,0 +1,9 @@
+# Archive of Rust Stable Standalone Installers
+
+**Note: The Rust project only supports the latest stable release with security patches.
+Generally speaking these archives should not be used without some extra mechanisms
+to provide for patching.**
+
+{{#include shared-standalone-installers.md}}
+
+{{#previous_stable_standalone_installers_tables}}

--- a/src/infra/other-installation-methods.md
+++ b/src/infra/other-installation-methods.md
@@ -79,26 +79,9 @@ what they each specifically generate.
 
 <span id="standalone"></span>
 
-The official Rust standalone installers contain a single release of Rust, and
-are suitable for offline installation. They come in three forms: tarballs
-(extension `.tar.xz`), that work in any Unix-like environment, Windows
-installers (`.msi`), and Mac installers (`.pkg`). These installers come with
-`rustc`, `cargo`, `rustdoc`, the standard library, and the standard
-documentation, but do not provide access to additional cross-targets like
-`rustup` does.
+{{#include shared-standalone-installers.md}}
 
-The most common reasons to use these are:
-
-- Offline installation
-- Preferring a more platform-integrated, graphical installer on Windows
-
-Each of these binaries is signed with the [Rust signing key], which is
-[available on keybase.io], by the Rust build infrastructure, with [GPG]. In the
-tables below, the `.asc` files are the signatures.
-
-<!-- FIXME: Show this sentence again once we've found a quick way to display the archives.
-Past releases can be found in [the archives].
--->
+Past releases can be found in [the archive].
 
 {{#installer_table}}
 
@@ -170,8 +153,4 @@ diff rustc-*-src.tar build/dist/rustc-*-src.tar
 [chocolatey]: http://chocolatey.org/
 [scoop]: https://scoop.sh/
 [three tiers]: https://doc.rust-lang.org/nightly/rustc/platform-support.html
-[rust signing key]: https://static.rust-lang.org/rust-key.gpg.ascii
-[gpg]: https://gnupg.org/
-[available on keybase.io]: https://keybase.io/rust
-[the archives]: https://static.rust-lang.org/dist/index.html
-
+[the archive]: ../infra/archive-stable-version-installers.md

--- a/src/infra/shared-standalone-installers.md
+++ b/src/infra/shared-standalone-installers.md
@@ -1,0 +1,20 @@
+The official Rust standalone installers contain a single release of Rust, and
+are suitable for offline installation. They come in three forms: tarballs
+(extension `.tar.xz`), that work in any Unix-like environment, Windows
+installers (`.msi`), and Mac installers (`.pkg`). These installers come with
+`rustc`, `cargo`, `rustdoc`, the standard library, and the standard
+documentation, but do not provide access to additional cross-targets like
+`rustup` does.
+
+The most common reasons to use these are:
+
+- Offline installation
+- Preferring a more platform-integrated, graphical installer on Windows
+
+Each of these binaries is signed with the [Rust signing key], which is
+[available on keybase.io], by the Rust build infrastructure, with [GPG]. In the
+tables below, the `.asc` files are the signatures.
+
+[rust signing key]: https://static.rust-lang.org/rust-key.gpg.ascii
+[available on keybase.io]: https://keybase.io/rust
+[gpg]: https://gnupg.org/


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust-forge/issues/676

This PR adds a new page "Archive of Rust Stable Standalone Installers" that contains a list of tables of previous stable Rust version standalone installers.

Currently it works for all versions > 1.8. Versions <= 1.7 do not have v2 toml manifests. See Zulip for [details](https://rust-lang.zulipchat.com/#narrow/stream/241545-t-release/topic/Manifest.20files.20for.20stable.20channel.20.3C.3D.201.2E7.3F/near/428281514).

@shepmaster @ojeda Is this what you had in mind?

Screenshots:

<img width="1680" alt="Screenshot 2024-03-22 at 3 33 08 AM" src="https://github.com/rust-lang/rust-forge/assets/5137691/5d814ef1-c158-45d8-a376-06124dbba3f0">

<img width="1680" alt="Screenshot 2024-03-22 at 3 33 41 AM" src="https://github.com/rust-lang/rust-forge/assets/5137691/c39f0ee5-da18-45f5-8715-b10362b24c8c">
