### PR TITLE
Use `.tar.xz` instead of `.tar.gz` for archive links

### DIFF
--- a/blacksmith/src/lib.rs
+++ b/blacksmith/src/lib.rs
@@ -174,7 +174,7 @@ impl Blacksmith {
             } else if name.contains("darwin") {
                 "pkg"
             } else {
-                "tar.gz"
+                "tar.xz"
             };
 
             let stable_links = platform
@@ -224,7 +224,7 @@ impl Blacksmith {
                     buffer,
                     "stable ({}) | {}",
                     stable_version,
-                    generate_standalone_links("rustc", stable_version, "src", "tar.gz")
+                    generate_standalone_links("rustc", stable_version, "src", "tar.xz")
                 )
                 .unwrap();
             } else {
@@ -232,7 +232,7 @@ impl Blacksmith {
                     buffer,
                     "{} | {}",
                     channel,
-                    generate_standalone_links("rustc", &channel, "src", "tar.gz")
+                    generate_standalone_links("rustc", &channel, "src", "tar.xz")
                 )
                 .unwrap();
             }

--- a/src/infra/other-installation-methods.md
+++ b/src/infra/other-installation-methods.md
@@ -81,7 +81,7 @@ what they each specifically generate.
 
 The official Rust standalone installers contain a single release of Rust, and
 are suitable for offline installation. They come in three forms: tarballs
-(extension `.tar.gz`), that work in any Unix-like environment, Windows
+(extension `.tar.xz`), that work in any Unix-like environment, Windows
 installers (`.msi`), and Mac installers (`.pkg`). These installers come with
 `rustc`, `cargo`, `rustdoc`, the standard library, and the standard
 documentation, but do not provide access to additional cross-targets like


### PR DESCRIPTION
Related to https://github.com/rust-lang/infra-team/issues/89.