### PR TITLE
Use a different method to compare source tarball archives

### DIFF
--- a/src/infra/other-installation-methods.md
+++ b/src/infra/other-installation-methods.md
@@ -151,11 +151,10 @@ wget https://ci-artifacts.rust-lang.org/rustc-builds/${TAG}/rustc-nightly-src.ta
 # Download a source tarball for a stable release
 # wget https://static.rust-lang.org/dist/rustc-${TAG}-src.tar.xz
 
-# Decompress the tarballs and compare their contents
-cd build/dist
-mkdir archive-local && tar -xf rustc-*-src.tar.xz --strip-components=1 -Carchive-local
-mkdir archive-ci && tar -xf ../../rustc-*-src.tar.xz --strip-components=1 -Carchive-ci 
-diff --brief --recursive archive-local archive-ci
+# Decompress the tarballs and check if they're the same
+xz --decompress rustc-*-src.tar.xz
+xz --decompress build/dist/rustc-*-src.tar.xz
+diff rustc-*-src.tar build/dist/rustc-*-src.tar
 ```
 
 </details>


### PR DESCRIPTION
To avoid extracting the archives.

https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/Separate.20CI.20workflow.20for.20source.20tarballs/near/430505788