### PR TITLE
triagebot: Add documentation for transfer command.

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -20,6 +20,7 @@
     - [Documentation Updates](./triagebot/doc-updates.md)
     - [GitHub Releases](./triagebot/github-releases.md)
     - [Glacier](./triagebot/glacier.md)
+    - [Issue Transfer](./triagebot/transfer.md)
     - [Labeling](./triagebot/labeling.md)
     - [Major Changes](./triagebot/major-changes.md)
     - [Mentions](./triagebot/mentions.md)

--- a/src/triagebot/transfer.md
+++ b/src/triagebot/transfer.md
@@ -1,0 +1,36 @@
+# Issue Transfer
+
+The `transfer` command allows you to transfer a GitHub issue from one repository to another.
+
+## Usage
+
+To transfer an issue to another repository, enter a comment with the form:
+
+`@rustbot transfer` *repository-name*
+
+It is recommended to also include a comment explaining why you are transferring. For example:
+
+```
+Transferring to rust-lang/cargo since this is an issue with how cargo
+implements diagnostic reports.
+
+@rustbot transfer cargo
+```
+
+**IMPORTANT: There will be no visual indication that the issue is being transferred.** Due to GitHub API limitations, you will not see any activity. **You must reload the page** to view the issue in its new location. It may take a few moments for GitHub to transfer all the data.
+
+**WARNING:** Transferring is a partially destructive command. For example, labels and milestones that don't exist in the target repository will be removed.
+
+The transfer command is limited to team members of the rust-lang org, and transfers can only happen to repositories in the rust-lang org.
+
+## Configuration
+
+The source repository must have an empty `transfer` table to enable transfers *from* that repository. Issues can be transferred to any repository in the rust-lang org.
+
+```toml
+[transfer]
+```
+
+## Implementation
+
+See [`parser/src/command/transfer.rs`](https://github.com/rust-lang/triagebot/blob/HEAD/parser/src/command/transfer.rs) and [`src/handlers/transfer.rs`](https://github.com/rust-lang/triagebot/blob/HEAD/src/handlers/transfer.rs).

--- a/src/triagebot/transfer.md
+++ b/src/triagebot/transfer.md
@@ -6,7 +6,7 @@ The `transfer` command allows you to transfer a GitHub issue from one repository
 
 To transfer an issue to another repository, enter a comment with the form:
 
-`@rustbot transfer` *repository-name*
+`@rustbot transfer <repository-name>`
 
 It is recommended to also include a comment explaining why you are transferring. For example:
 
@@ -19,7 +19,7 @@ implements diagnostic reports.
 
 **IMPORTANT: There will be no visual indication that the issue is being transferred.** Due to GitHub API limitations, you will not see any activity. **You must reload the page** to view the issue in its new location. It may take a few moments for GitHub to transfer all the data.
 
-**WARNING:** Transferring is a partially destructive command. For example, labels and milestones that don't exist in the target repository will be removed.
+**WARNING:** Transferring is a partially destructive command. For example, labels and milestones that don't exist in the target repository will be removed from the issue.
 
 The transfer command is limited to team members of the rust-lang org, and transfers can only happen to repositories in the rust-lang org.
 


### PR DESCRIPTION
This adds documentation for the new transfer command added in https://github.com/rust-lang/triagebot/pull/1780