### PR TITLE
Update Zulip issue team nomination template

### DIFF
--- a/src/triagebot/zulip-notifications.md
+++ b/src/triagebot/zulip-notifications.md
@@ -46,7 +46,9 @@ message_on_close = "Issue #{number} has been closed. Thanks for participating!"
 message_on_reopen = "Issue #{number} has been reopened. Pinging @*T-types*."
 
 # The Zulip notification will not be posted unless the issue/PR has all of these labels.
-required_labels = ["I-nominated"]
+# Please replace the `{team}` placeholder with the appropriate team to be notified for the nomination
+# (ex. `I-compiler-nominated`, `I-lang-nominated`, ...)
+required_labels = ["I-{team}-nominated"]
 ```
 
 ## Implementation


### PR DESCRIPTION
Here's a small documentation update to show how to use the new nomination label (we include a placeholder to point to the nomination to specific team

See: https://github.com/rust-lang/triagebot/pull/1766 and https://github.com/rust-lang/rust/pull/119959

r? @ehuss 

thanks!