### PR TITLE
Update council.md

### DIFF
--- a/src/governance/council.md
+++ b/src/governance/council.md
@@ -124,14 +124,12 @@ When the Council creates a new top-level team, that team then designates a Counc
 The set of top-level teams is:
 
 - Compiler
-- Crates.io
 - Dev tools
 - Infrastructure
 - Language
 - Launching Pad
 - Library
 - Moderation
-- Release
 
 ### The Launching Pad top-level team
 [launching-pad]: #the-launching-pad-top-level-team


### PR DESCRIPTION
Updates the list of top level teams on the council. Some teams have been combined, leaving a total of seven current top level teams.

NB: https://www.rust-lang.org/governance/teams/leadership-council for current status.