### PR TITLE
Add support for stable versions before 1.8.0

### DIFF
--- a/blacksmith/src/lib.rs
+++ b/blacksmith/src/lib.rs
@@ -198,6 +198,62 @@ impl Blacksmith {
             previous_stable_version_map.insert((minor, patch), (version, platforms));
         }
 
+        // There are no manifests for stable versions before 1.8.0,
+        // so we hardcode them instead.
+        // i686-pc-windows-msvc wasn't supported until version 1.3.0.
+        for minor in 3..8 {
+            previous_stable_version_map.insert(
+                (minor, 0),
+                (
+                    format!("1.{}.0", minor),
+                    Vec::from([
+                        "i686-apple-darwin".to_string(),
+                        "i686-pc-windows-gnu".to_string(),
+                        "i686-pc-windows-msvc".to_string(),
+                        "i686-unknown-linux-gnu".to_string(),
+                        "x86_64-apple-darwin".to_string(),
+                        "x86_64-pc-windows-gnu".to_string(),
+                        "x86_64-pc-windows-msvc".to_string(),
+                        "x86_64-unknown-linux-gnu".to_string(),
+                    ]),
+                ),
+            );
+        }
+
+        // x86_64-pc-windows-msvc wasn't supported until version 1.2.0.
+        previous_stable_version_map.insert(
+            (2, 0),
+            (
+                "1.2.0".to_string(),
+                Vec::from([
+                    "i686-apple-darwin".to_string(),
+                    "i686-pc-windows-gnu".to_string(),
+                    "i686-unknown-linux-gnu".to_string(),
+                    "x86_64-apple-darwin".to_string(),
+                    "x86_64-pc-windows-gnu".to_string(),
+                    "x86_64-pc-windows-msvc".to_string(),
+                    "x86_64-unknown-linux-gnu".to_string(),
+                ]),
+            ),
+        );
+
+        for minor in 0..2 {
+            previous_stable_version_map.insert(
+                (minor, 0),
+                (
+                    format!("1.{}.0", minor),
+                    Vec::from([
+                        "i686-apple-darwin".to_string(),
+                        "i686-pc-windows-gnu".to_string(),
+                        "i686-unknown-linux-gnu".to_string(),
+                        "x86_64-apple-darwin".to_string(),
+                        "x86_64-pc-windows-gnu".to_string(),
+                        "x86_64-unknown-linux-gnu".to_string(),
+                    ]),
+                ),
+            );
+        }
+
         for (_, (version, platforms)) in previous_stable_version_map.into_iter().rev() {
             blacksmith
                 .previous_stable_versions


### PR DESCRIPTION
## Changes

Add support for stable versions before 1.8.0.

## Why

I added Archive of Rust Stable Standalone Installers [page](https://forge.rust-lang.org/infra/archive-stable-version-installers.html) in https://github.com/rust-lang/rust-forge/pull/733 and https://github.com/rust-lang/rust-forge/pull/770.

Currently it works for all versions >= 1.8.0. Versions <= 1.7.0 do not have manifests. See Zulip for [details](https://rust-lang.zulipchat.com/#narrow/stream/241545-t-release/topic/Manifest.20files.20for.20stable.20channel.20.3C.3D.201.2E7.3F/near/428281514).

So in this PR I hard code the available platforms for stable versions before 1.8.0. I got the list of the supported platforms for each version by trying to download (similar to what rustup does for them). I tested that I am able to download the artifacts from the final Forge page.

Screenshot with versions 1.0.0 and 1.1.0 available:

![Screenshot 2024-10-15 at 10 15 35 AM](https://github.com/user-attachments/assets/77fe9698-9cd5-42e5-9cfd-0748d06acd5d)
