### PR TITLE
Include toml files when searching for `#[cfg(bootstrap)]`

### DIFF
--- a/src/release/process.md
+++ b/src/release/process.md
@@ -129,7 +129,7 @@ Send a PR to the master branch to:
   running this command:
 
   ```
-  rg '#!?\[.*\(bootstrap' -t rust
+  rg '#!?\[.*\(bootstrap' -t rust -t toml
   ```
 
   The general guidelines (both for `#[]` and `#![]`) are:


### PR DESCRIPTION
This is to not forget to remove boostrap references like `check-cfg` lint config in `Cargo.toml` files:

https://github.com/rust-lang/rust/blob/9618da7c9995a673af4841149ba2d1f53b69dd92/library/core/Cargo.toml#L46-L47

r? @cuviper 