### PR TITLE
Remove mention of label needs-triage-legacy which is no more

### DIFF
--- a/src/release/issue-triaging.md
+++ b/src/release/issue-triaging.md
@@ -67,9 +67,6 @@ Another useful thing to do is go through `E-needs-mcve` and `E-needs-bisection` 
 (using [cargo-bisect-rustc](`https://github.com/rust-lang/cargo-bisect-rustc`)). When you provide one, you can also remove the label
 using rustbot (`@rustbot label -E-needs-bisection`).
 
-At the time of writing, there is also the `needs-triage-legacy` label, for older issues that are suspected to not have been triaged.
-Triaging them the same way as `needs-triage` is also useful.
-
 ## Labels
 
 There are many different labels that can be applied to issues.


### PR DESCRIPTION
Sometime in the last 24 hours, the remaining ~20 needs-triage-legacy issues have been triaged and the label has subsequently been removed which I happened to notice. I presume it was one of @Enselic @jieyouxu?

In any case, needs-triage-legacy is no more, rejoice! We started at >500 (?) issues >1 year ago and gradually chipped away at it. Thanks all who contributed to that effort!

---

I wonder if we should replace that section with other "further triaging" "techniques"? For example, I very often use the GitHub queries `comments:0` (without any comments), `sort:updated-asc` (least recently updated) (the latter is rather obvious).