### PR TITLE
Add note about running clippy ci during the release process

### DIFF
--- a/src/release/process.md
+++ b/src/release/process.md
@@ -146,6 +146,12 @@ Send a PR to the master branch to:
   they won't have to be removed. The easiest way to handle this is to change
   them anyway and let CI show you the failure.
 
+- Ensure there are no new warnings or Clippy lints affecting the codebase:
+
+  ```
+  ./x clippy ci
+  ```
+
 ## Release day (Thursday)
 
 Decide on a time to do the release. You are fully in charge of deciding when


### PR DESCRIPTION
Now that https://github.com/rust-lang/rust/pull/132649 got merged (thanks @klensy!) we should add a step to the master update recommending to run the command and fix the lints it points out, to avoid the failure happening in CI.

r? @Mark-Simulacrum 