### PR TITLE
triagebot: fix review-submitted docs

### DIFF
--- a/src/triagebot/review-submitted.md
+++ b/src/triagebot/review-submitted.md
@@ -16,7 +16,7 @@ This feature is enabled on a repository by having a `[review-submitted]` table i
 # These labels are removed when a review is submitted.
 review_labels = ["S-waiting-on-review"]
 # This label is added when a review is submitted.
-reviewed_label = ["S-waiting-on-author"]
+reviewed_label = "S-waiting-on-author"
 ```
 
 ## Implementation


### PR DESCRIPTION
There's only one `reviewed_label`, not a list of them. Also see the [code](https://github.com/rust-lang/triagebot/blob/d7d4babe564e264ea4824bba1ba55a8088d8a9fd/src/config.rs#L305).