### PR TITLE
Add documentation for rendered link triagebot handler

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -30,6 +30,7 @@
     - [Note](./triagebot/note.md)
     - [Notifications](./triagebot/notifications.md)
     - [Pinging](./triagebot/pinging.md)
+    - [Rendered link](./triagebot/rendered-link.md)
     - [Requesting Prioritization](./triagebot/requesting-prioritization.md)
     - [Review Changes Requested](./triagebot/review-submitted.md)
     - [Review Requested](./triagebot/review-requested.md)

--- a/src/triagebot/rendered-link.md
+++ b/src/triagebot/rendered-link.md
@@ -1,0 +1,18 @@
+# Rendered link
+
+Rendered links are simple hyperlinks that are automatically added (and updated) to a PR description by triagebot.
+
+## Configuration
+
+This feature is enabled on a repository by having a `[rendered-link]` table in `triagebot.toml`:
+
+```toml
+[rendered-link]
+trigger-files = ["posts/"]
+```
+
+The `trigger-files` key configures which directories are watched for modification, with the "Rendered link" pointing to the first file matching.
+
+## Implementation
+
+See [`src/handlers/rendered_link.rs`](https://github.com/rust-lang/triagebot/blob/HEAD/src/handlers/rendered_link.rs).


### PR DESCRIPTION
This PR adds documentation for rendered link triagebot handler.

Following https://github.com/rust-lang/triagebot/pull/1868

r? @ehuss