### PR TITLE
link to stabilization docs in the rustc-dev-guide

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -104,6 +104,7 @@
 - [Language](./lang/README.md)
     - [RFC Merge Procedure](./lang/rfc-merge-procedure.md)
     - [Triage Meeting Procedure](./lang/triage-meeting-procedure.md)
+    - [Stabilization procedure](./lang/stabilization-procedure.md)
 - [Libs](./libs/README.md)
     - [Maintaining the standard library](./libs/maintaining-std.md)
 - [Release](./release/README.md)

--- a/src/lang/stabilization-procedure.md
+++ b/src/lang/stabilization-procedure.md
@@ -1,0 +1,3 @@
+# Stabilization procedure for language features
+
+See the ["Request for stabilization" chapter in the rustc-dev-guide](https://rustc-dev-guide.rust-lang.org/stabilization_guide.html) for documentation on the stabilization procedure.


### PR DESCRIPTION
Seems like we should copiously cross-link.