### PR TITLE
Remove "Survey FAQ" deadlink from SUMMARY

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -41,7 +41,6 @@
     - [Zulip Notifications](./triagebot/zulip-notifications.md)
     - [GitHub Actions created PR open/closer](./triagebot/bot-pull-requests.md)
 - [Community](./community/README.md)
-    - [State of Rust Survey FAQ](./community/survey-faq.md)
 - [Compiler](./compiler/README.md)
     - [Cross Compilation](./compiler/cross-compilation/README.md)
         - [Windows](./compiler/cross-compilation/windows.md)


### PR DESCRIPTION
Currently just shows a blank page, because `community/survey-faq.md` had been removed by #807.

[Rendered](https://github.com/Marcono1234/rust-forge/blob/patch-1/src/SUMMARY.md)