### PR TITLE
Move to the forge remaining T-compiler docs

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -52,6 +52,7 @@
     - [Proposals, Approval and Stabilization](./compiler/proposals-and-stabilization.md)
     - [Third-party and Out-of-tree Crates Policy](./compiler/third-party-out-of-tree.md)
     - [Triage and Prioritization](./compiler/prioritization.md)
+    - [Operations](./compiler/operations.md)
 - [crates.io](./crates-io/README.md)
     - [Crate removal](./crates-io/crate-removal.md)
     - [Database maintenance](./crates-io/db-maintenance.md)

--- a/src/compiler/README.md
+++ b/src/compiler/README.md
@@ -25,3 +25,5 @@ you're looking for the [rustc-dev-guide](https://rustc-dev-guide.rust-lang.org/)
      the compiler?*
 - [Triage and Prioritization](./prioritization.md)
   - *How are compiler issues triaged and prioritized?*
+- [Operations](./operations.md)
+  - *Supporting the compiler team*

--- a/src/compiler/meetings.md
+++ b/src/compiler/meetings.md
@@ -9,6 +9,8 @@ performance triage reports and discussing nominated issues. Triage meetings are 
 [the team calendar](./calendar.md). Anyone can attend and it is recommended that compiler team
 members do.
 
+Agendas of triage meetings are stored on [HackMD][meeting_triage_notes].
+
 ### Generating the triage meeting agenda
 See [*Prioritization*](./prioritization.md) for documentation on generating the triage meeting
 agenda.
@@ -19,7 +21,7 @@ discussions. Steering/planning meetings operate on a repeating schedule:
 
 - **Week 1:** Planning meeting
   - Select the topics for the next three meetings from the team's proposed meetings.
-- **Week 2-4:** Steering meeting 
+- **Week 2-4:** Steering meeting
   - Discuss the planned topic.
 
 During planning meetings, the team lead running the meeting will attempt to identify topics which
@@ -52,5 +54,9 @@ Any contributor can propose a meeting topic. Some examples of good steering meet
 Scheduled planning and steering meetings can be found on the [compiler team's
 calendar](./calendar.md).
 
+Minutes of steering meetings are stored on [HackMD][meeting_steering_notes].
+
 [team_repo]: https://github.com/rust-lang/compiler-team
 [meetings_channel]: https://rust-lang.zulipchat.com/#narrow/channel/238009-t-compiler.2Fmeetings
+[meeting_steering_notes]: https://hackmd.io/team/rust-compiler-team?nav=overview&tags=%5B%22steering%22%5D&tagtree-filter=true
+[meeting_triage_notes]: https://hackmd.io/team/rust-compiler-team?nav=overview&tags=%5B%22weekly%22%5D&tagtree-filter=true

--- a/src/compiler/operations.md
+++ b/src/compiler/operations.md
@@ -1,0 +1,45 @@
+# Operations
+
+Here is a list of recurring tasks to support the compiler team and help keep things moving forward. Ideally run through this list every week. If there are blockers or doubts, after having acquired the right context, don't hesitate to ping people around. Keep in mind that contributors are the best resource of the project and we want to be mindful of their time.
+
+## Issues hygiene
+
+- [Issue to be prioritized](https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AI-prioritize): see [prioritization](https://forge.rust-lang.org/compiler/prioritization.html).
+- [P-high issues without assignee](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee): ideally this category of issues should have an assignee (filter out those without a PR).In rare cases it's fine if they don't.
+- [MCP in FCP status](https://github.com/rust-lang/compiler-team/issues?q=is%3Aissue+is%3Aopen+label%3Afinal-comment-period+sort%3Acreated-asc), close seconded since more 10 days, ensure no open concerns
+- [Check open MCPs](https://github.com/rust-lang/compiler-team/issues?q=is%3Aissue+is%3Aopen+label%3Amajor-change+-label%3Afinal-comment-period+sort%3Aupdated-asc): [MCP is a protocol](https://forge.rust-lang.org/compiler/proposals-and-stabilization.html) to bring proposals to the compiler team attention. Ensure MCPs are moving towards one of these two outcome, being seconded or being closed for lack of seconding. When it's clear that an MCP won't be seconded or is abandoned, after about two or three months is ok to query its status and evaluate closing it. Otherwise try to get them unstuck.
+- [Issues needing a reproducible](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AE-needs-mcve+label%3AT-compiler+sort%3Acreated-asc)
+- [Issues and PRs that are going through FCP](https://github.com/rust-lang/rust/issues?q=sort%3Aupdated-desc+label%3Afinished-final-comment-period): check if the team need to check their box. These issues are in the weekly triage agenda.
+
+## Prioritization for T-compiler
+
+Some useful filters when looking at regressions.
+
+- [Nightly regressions without priority](https://github.com/rust-lang/rust/issues?q=is%3Aissue+label%3AT-compiler+label%3Aregression-from-stable-to-nightly+-label%3AI-prioritize++is%3Aopen)
+- [Beta regressions without priority](https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3Aregression-from-stable-to-beta+-label%3AI-prioritize)
+- [Stable regressions without priority](https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3Aregression-from-stable-to-stable+-label%3AI-prioritize)
+- [Untriaged regressions without a priority](https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3Aregression-untriaged+-label%3AP-critical+-label%3AP-high+-label%3AP-medium+-label%3AP-low+-label%3AI-prioritize)
+
+## PRs hygiene
+
+- Every PR should have a team assigned
+  - [PR without a team label](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+-label%3AT-libs-api+-label%3AT-libs+-label%3AT-rustdoc+-label%3AT-compiler+-label%3AT-lang+-label%3AT-infra+-label%3AT-release+-label%3AT-types+-label%3AT-style+-label%3AT-bootstrap+-label%3AT-opsem+sort%3Acreated-asc)
+  - [Waiting on author](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+-label%3AT-libs-api+-label%3AT-libs+-label%3AT-rustdoc+-label%3AT-compiler+-label%3AT-lang+-label%3AT-infra+-label%3AT-release+-label%3AT-types+-label%3AT-style+-label%3AT-bootstrap+label%3AS-waiting-on-author+sort%3Aupdated-asc)
+  - [Waiting on a review](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+-label%3AT-libs-api+-label%3AT-libs+-label%3AT-rustdoc+-label%3AT-compiler+-label%3AT-lang+-label%3AT-infra+-label%3AT-release+-label%3AT-types+-label%3AT-style+-label%3AT-bootstrap+label%3AS-waiting-on-review+sort%3Aupdated-asc)
+
+## Things to do a week before the release:
+
+- [No regression without priority](https://github.com/rust-lang/compiler-team/issues?q=is%3Aissue+is%3Aopen+label%3Afinal-comment-period+sort%3Acreated-asc): ensure they've been fixed and if not try to get the team attention.
+- No [beta regressions](https://github.com/rust-lang/compiler-team/issues?q=is%3Aissue+is%3Aopen+label%3Afinal-comment-period+sort%3Acreated-asc) or [stable regressions](https://github.com/rust-lang/compiler-team/issues?q=is%3Aissue+is%3Aopen+label%3Afinal-comment-period+sort%3Acreated-asc) regressions without an owner, filter out those out without a PR.
+- No [beta regressions](https://github.com/rust-lang/rust/issues?q=label%3Aregression-from-stable-to-beta+label%3AT-compiler+is%3Aopen) or [stable regressions](https://github.com/rust-lang/rust/issues?q=label%3Aregression-from-stable-to-stable+label%3AT-compiler+is%3Aopen) regressions work in progress, ideally they should all be merged.
+- Ensure breaking changes (i.e. regressions agreed to be acceptable) has a corresponding issue tagged `relnotes-tracking-issue`, see [list of release notes](https://github.com/rust-lang/rust/issues?q=sort%3Aupdated-desc+is%3Aopen+label%3Arelnotes-tracking-issue). T-release will then pick them up and add them to the release notes.
+
+## After the release
+
+- Check which regressions can be closed as "accepted". Add a comment clarifying that the PR causing the regression is accepted as breaking change, example: "Closing since PR #123456 will be mentioned in the release notes". Check carefully, don't be trigger-happy. Discussions and comments about this practice can be directed on [Zulip](https://rust-lang.zulipchat.com/#narrow/channel/242269-t-release.2Ftriage/topic/beta.20regressions.20that.20are.20no.20more/near/456509338).
+
+## Rest of the world
+
+These filters are for checking what's happening in other teams
+
+- [List of open RFCs](https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3Aproposed-final-comment-period+label%3Adisposition-merge+sort%3Aupdated-asc) (all teams) waiting for the team to discuss or check the proposal, can anything be done to help moving them forward?

--- a/src/compiler/prioritization.md
+++ b/src/compiler/prioritization.md
@@ -132,9 +132,11 @@ To assign a priority, replace the `I-prioritize` label with one of `P-critical`,
 `P-medium` or `P-low` and adding a succinct comment to link the Zulip discussion where the issue
 prioritization occurred, example of a template for the comment:
 
-> WG-prioritization assigning priority ([Zulip discussion](#)).
+> Assigning priority (discussion on [Zulip](#)).
 >
 > @rustbot label -I-prioritize +P-XXX
+
+Tip: use [Github Saved Replies](https://docs.github.com/get-started/writing-on-github/working-with-saved-replies) to create a template comment.
 
 Ideally, all [`T-compiler` issues with a `I-prioritize` label][issues_needing_prio] to have a
 priority assigned, or strive to reach this goal: sometimes different factors are blocking issues
@@ -151,7 +153,7 @@ try to ensure they are assigned when possikle.
 [beta_regressions]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+-label%3AP-critical+-label%3AP-high+-label%3AP-medium+-label%3AP-low+-label%3AT-infra+-label%3AT-libs+-label%3AT-libs-api+-label%3AT-release+-label%3AT-rustdoc
 [nightly_regressions]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+-label%3AP-critical+-label%3AP-high+-label%3AP-medium+-label%3AP-low+-label%3AT-infra+-label%3AT-libs+-label%3AT-libs-api+-label%3AT-release+-label%3AT-rustdoc
 
-The final step prior to generating the agenda is to accept any MCPs. Any MCPs that have had [the `final-comment-period` label][mcp_fcp] 
+The final step prior to generating the agenda is to accept any MCPs. Any MCPs that have had [the `final-comment-period` label][mcp_fcp]
 for more than ten days can be accepted. Remove the `final-comment-period` label and add the `major-change-accepted` label and then
 close the issue.
 
@@ -176,7 +178,7 @@ Copy the content into a new HackMD in the "Rust Lang Compiler Team" space. Copy 
 Add additional manual details to the agenda:
 
 - Add summaries of stable/beta nominations (e.g. who nominated the backport and why)
-- Add summaries of PRs waiting on the team (i.e. why are they waiting) 
+- Add summaries of PRs waiting on the team (i.e. why are they waiting)
 - Add initial impressions of `P-critical`/`P-high` bugs
 - Add summaries of nominated issues (e.g. who the assignee is, why it was nominated, etc)
 - Populate the oldest PRs waiting on review
@@ -184,13 +186,13 @@ Add additional manual details to the agenda:
     experiment, it may not need a review; how long has it been since review activity; what do
     recent comments say?)
 
-Two hours prior to the meeting, announce and share the completed agenda in the Zulip thread for the
+About two hours prior to the meeting, announce and share the completed agenda in the Zulip thread for the
 upcoming meeting (creating it if it does not already exist):
 
 ```text
-Hi @*T-compiler/meeting*; the triage meeting will happen tomorrow in about 2 hours.
-*WG-prioritization* has done pre-triage in #**t-compiler/wg-prioritization/alerts**
-@*WG-prioritization* has prepared the [meeting agenda](link_to_hackmd_agenda)
+Hello @*T-compiler/meeting*, triage meeting in about 2h
+Pre-triage done in #**t-compiler/wg-prioritization/alerts**.
+Meeting agenda [on HackMD](https://hackmd.io/link_to_hackmd_agenda)
 ```
 
 It is always recommended to re-run the generator and copy any new details over to the agenda as
@@ -218,12 +220,12 @@ After the meeting, there are a few closing tasks:
   the `I-compiler-nominated` will stick until next meeting. Create a new agenda stub for the
   following.
 
-[beta_nominated]: https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted
-[stable_nominated]: https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted
-[rust_announce]: https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Afinished-final-comment-period+label%3Ato-announce
-[team_announce]: https://github.com/rust-lang/compiler-team/issues?q=is%3Aall+label%3Afinished-final-comment-period+label%3Ato-announce
-[forge_announce]: https://github.com/rust-lang/rust-forge/issues?q=is%3Aall+label%3Afinished-final-comment-period+label%3Ato-announce
-[fcps]: https://github.com/rust-lang/compiler-team/issues?q=is%3Aall+label%3Amajor-change+label%3Ato-announce
-[mcps]: https://github.com/rust-lang/compiler-team/issues?q=is%3Aall+label%3Amajor-change+label%3Ato-announce
+[beta_nominated]: https://github.com/rust-lang/rust/issues?q=is%3Apr+label%3Abeta-nominated+-label%3Abeta-accepted
+[stable_nominated]: https://github.com/rust-lang/rust/issues?q=is%3Apr+label%3Astable-nominated+-label%3Astable-accepted
+[rust_announce]: https://github.com/rust-lang/rust/issues?q=label%3Afinished-final-comment-period+label%3Ato-announce
+[team_announce]: https://github.com/rust-lang/compiler-team/issues?q=label%3Afinished-final-comment-period+label%3Ato-announce
+[forge_announce]: https://github.com/rust-lang/rust-forge/issues?q=label%3Afinished-final-comment-period+label%3Ato-announce
+[fcps]: https://github.com/rust-lang/compiler-team/issues?q=label%3Amajor-change+label%3Ato-announce
+[mcps]: https://github.com/rust-lang/compiler-team/issues?q=label%3Amajor-change+label%3Ato-announce
 [relese_backports]: ../release/backporting.md
-[compiler_nominated]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler
+[compiler_nominated]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-compiler-nominated+label%3AT-compiler


### PR DESCRIPTION
This is moving the last remaining bits of T-compiler documentation to the forge.

I have omitted the documentation about the working groupos because I don't have clear what we prefer to do (WGs as a structure seems that will be sunset in the future). My suggestion would be to migrate documentation about WGs in a follow-up PR. Meanwhile I'll figure out which are active and which are not.

[Rendered](https://github.com/apiraino/rust-forge/blob/move-compiler-docs/src/SUMMARY.md)

r? @davidtwco 