### PR TITLE
Add procedure when "Extending the behavior of a stable flag"

### DIFF
--- a/src/compiler/proposals-and-stabilization.md
+++ b/src/compiler/proposals-and-stabilization.md
@@ -198,6 +198,11 @@ circumstance.
   - **Approve using:** FCP
   - Open a PR and follow the [stabilization guide][stabilization_guide]. The assigned reviewer will
     check that the stabilization guide has been followed, review the code and start an FCP
+- Extending the behavior of a stable flag
+  - **Propose using:** MCP
+  - **Approve using:** Seconding
+  - Describe the rationale for extending the behavior of the flag. Once discussion has concluded,
+    a team member may second the proposal
 
 ### Attributes
 


### PR DESCRIPTION
This PR adds a procedure when one wants to extend the behavior of a stable flag.

Context for the procedure: https://github.com/rust-lang/rust/pull/138767

r? @davidtwco 

[Rendered](https://github.com/Urgau/rust-forge/blob/extend-behavior-stable-flag/src/compiler/proposals-and-stabilization.md)