### PR TITLE
Update T-compiler zulip channels' names

### DIFF
--- a/src/compiler/notification-groups.md
+++ b/src/compiler/notification-groups.md
@@ -2,6 +2,9 @@
 The compiler team has a number of notification groups that used to ping people and draw their
 attention to issues. Notification groups are setup so that anyone can join them if they want.
 
+Please keep in mind that only members of a Rust project GitHub team can use these notification
+groups. Non-team members will trigger an error from our automation bot.
+
 ## Creating a notification group
 If you'd like to create a notification group, here are the steps. First, you want to get approval
 from the compiler team:
@@ -17,8 +20,6 @@ from the compiler team:
 * Create a sample PR for the [rust-lang/team] repository showing how one can add
   oneself. This will be referenced by your blog post to show people how to
   join. [(Example PR)](https://github.com/rust-lang/team/pull/140)
-* Create a Zulip stream for the notification group. If you don't have the permission
-  to do, you can ask on [#t-compiler/wg-meta].
 * Write an announcement blog post for Inside Rust and open a PR against
   [blog.rust-lang.org](https://github.com/rust-lang/blog.rust-lang.org).
   [(Example PR)](https://github.com/rust-lang/blog.rust-lang.org/pull/615)
@@ -26,5 +27,4 @@ from the compiler team:
 [rust-lang/compiler-team]: https://github.com/rust-lang/compiler-team
 [rust-lang/team]: https://github.com/rust-lang/team
 [rust-lang/rust]: https://github.com/rust-lang/rust
-[#t-compiler/wg-meta]: https://rust-lang.zulipchat.com/#narrow/stream/185694-t-compiler.2Fwg-meta
 [MCP]: ./mcp.md

--- a/src/compiler/prioritization.md
+++ b/src/compiler/prioritization.md
@@ -124,7 +124,7 @@ First, ensure that relevant issues are labelled as `T-compiler`..
 ..and that prioritization has been completed. Regressions labeled with `I-prioritize` are signaling
 that a priority assessment is waiting. When this label is added to an issue, the `triagebot` creates
 automatically a notification for @*WG-prioritization* members on [the
-`#t-compiler/wg-prioritization/alerts` Zulip channel][prio_channel].
+`#t-compiler/prioritization/alerts` Zulip channel][prio_channel].
 
 [prio_channel]: https://rust-lang.zulipchat.com/#narrow/stream/245100-t-compiler.2Fwg-prioritization.2Falerts
 
@@ -190,8 +190,8 @@ About two hours prior to the meeting, announce and share the completed agenda in
 upcoming meeting (creating it if it does not already exist):
 
 ```text
-Hello @*T-compiler/meeting*, triage meeting in about 2h
-Pre-triage done in #**t-compiler/wg-prioritization/alerts**.
+Hello @*T-compiler/meeting*, triage meeting in about 2h.
+Pre-triage done in #**t-compiler/prioritization/alerts**.
 Meeting agenda [on HackMD](https://hackmd.io/link_to_hackmd_agenda)
 ```
 

--- a/src/compiler/working-areas.md
+++ b/src/compiler/working-areas.md
@@ -7,7 +7,7 @@ Name                                                      | Status       | Short
 [Async-await Implementation](working-groups/async-await/) | Active       | Implementing async-await                                                                           | [#wg-async][async-await_stream]
 [Diagnostics](working-groups/diagnostics/)                | Active       | Use crates.io crates for diagnostics rendering and make emitting diagnostics nicer.                | [#t-compiler/diagnostics][diagnostics_stream]
 [LLVM](working-groups/llvm/)                              | Active       | Working with LLVM upstream to represent Rust in its development                                    | [#t-compiler/llvm][llvm_stream]
-[MIR Optimizations](working-groups/mir-opt/)              | Active       | Write MIR optimizations and refactor the MIR to be more optimizable.                               | [#t-compiler/mir-opt][mir-opt-stream]
+[MIR Optimizations](working-groups/mir-opt/)              | Active       | Write MIR optimizations and refactor the MIR to be more optimizable.                               | [#t-compiler/mir-opts][mir-opts-stream]
 [Parallel-rustc](working-groups/parallel-rustc/)          | Paused       | Making parallel compilation the default for rustc                                                  | [#t-compiler/parallel-rustc][parallel-rustc_stream]
 [Polonius](working-groups/polonius/)                      | Active       | Exploring the integration of the "NLL 2.0"-like ["Polonius analysis"][Polonius] into rustc         | [#t-types/polonius][polonius_stream]
 [RLS 2.0](working-groups/rls-2.0/)                        | Active       | Experimenting with a new compiler architecture tailored for IDEs                                   | [#t-compiler/rust-analyzer][rls20_stream]
@@ -17,32 +17,32 @@ For historical record here's a list of Working Groups that are not active anymor
 
 Name                                                      | Status       | Short Description                                                                                  | Zulip Stream
 ----                                                      | ------       | -----------------                                                                                  | ------------
-[Meta](working-groups/meta/)                              | Paused       | How compiler team organizes itself                                                                 | [#t-compiler/meta][meta_stream]
-[Non-Lexical Lifetimes (NLL)](working-groups/nll/)        | Retired      | Implementing non-lexical lifetimes                                                                 | [#t-compiler/nll][nll_stream]
-[Polymorphization](working-groups/polymorphization/)      | Active       | Implement an analysis to detect when functions can remain polymorphic during code generation.      | [#t-compiler/polymorphization][polymorphization_stream]
+[Meta](working-groups/meta/)                              | Paused       | How compiler team organizes itself                                                                 | [#z-archived-t-compiler/wg-meta][meta_stream]
+[Non-Lexical Lifetimes (NLL)](working-groups/nll/)        | Retired      | Implementing non-lexical lifetimes                                                                 | [#z-archived-t-compiler/wg-nll][nll_stream]
+[Polymorphization](working-groups/polymorphization/)      | Active       | Implement an analysis to detect when functions can remain polymorphic during code generation.      | [#z-archived-t-compiler/wg-polymorphization][polymorphization_stream]
 [Prioritization](working-groups/prioritization/)          | Active       | Triaging bugs, mainly deciding if bugs are critical (potential release blockers) or not.           | [#t-compiler/prioritization][prioritization_stream]
-[Profile-Guided Optimization](working-groups/pgo/)        | Retired      | Implementing profile-guided optimization for rustc                                                 | [#t-compiler/profile-guided-optimization][pgo_stream]
-[RFC 2229](working-groups/rfc-2229/)                      | Retired      | Make a closure capture individual fields of the variable rather than the entire composite variable | [#t-compiler/rfc-2229][rfc-2229-stream]
-[Rustc pipelining](working-groups/pipelining/)            | Retired      | Enable Cargo to invoke rustc in a pipelined fashion, speeding up crate graph compiles.             | [#t-compiler/pipelining][pipelining-stream]
-[Self-Profile](working-groups/self-profile/)              | Active       | Improving the `-Z self-profile` feature                                                            | [#t-compiler/self-profile][self-profile_stream]
-[Traits](working-groups/traits/)                          | Active       | Improving the trait-system design + implementation                                                 | [#t-compiler/traits][traits_stream]
+[Profile-Guided Optimization](working-groups/pgo/)        | Retired      | Implementing profile-guided optimization for rustc                                                 | [#z-archived-t-compiler/wg-profile-guided-optimization][pgo_stream]
+[RFC 2229](working-groups/rfc-2229/)                      | Retired      | Make a closure capture individual fields of the variable rather than the entire composite variable | [#z-archived-t-compiler/wg-rfc-2229][rfc-2229-stream]
+[Rustc pipelining](working-groups/pipelining/)            | Retired      | Enable Cargo to invoke rustc in a pipelined fashion, speeding up crate graph compiles.             | [#z-archived-t-compiler/wg-pipelining][pipelining-stream]
+[Self-Profile](working-groups/self-profile/)              | Active       | Improving the `-Z self-profile` feature                                                            | [#z-archived-t-compiler/wg-self-profile][self-profile_stream]
+[Traits](working-groups/traits/)                          | Active       | Improving the trait-system design + implementation                                                 | [#z-archived-t-compiler/wg-traits][traits_stream]
 
 [Weekly, in Zulip]: #meeting-calendar
-[nll_stream]: https://rust-lang.zulipchat.com/#narrow/stream/122657-t-compiler.2Fwg-nll
+[nll_stream]: https://rust-lang.zulipchat.com/#narrow/channel/122657-z-archived-t-compiler.2Fwg-nll
 [llvm_stream]: https://rust-lang.zulipchat.com/#narrow/stream/187780-t-compiler.2Fwg-llvm
-[meta_stream]: https://rust-lang.zulipchat.com/#narrow/stream/185694-t-compiler.2Fwg-meta
+[meta_stream]: https://rust-lang.zulipchat.com/#narrow/channel/185694-z-archived-t-compiler.2Fwg-meta
 [rls20_stream]: https://rust-lang.zulipchat.com/#narrow/channel/185405-t-compiler.2Frust-analyzer
 [traits_stream]: https://rust-lang.zulipchat.com/#narrow/stream/144729-t-compiler.2Fwg-traits
 [async-await_stream]: https://rust-lang.zulipchat.com/#narrow/channel/187312-wg-async
 [self-profile_stream]: https://rust-lang.zulipchat.com/#narrow/stream/187831-t-compiler.2Fwg-self-profile
-[pgo_stream]: https://rust-lang.zulipchat.com/#narrow/stream/187830-t-compiler.2Fwg-profile-guided-optimization
+[pgo_stream]: https://rust-lang.zulipchat.com/#narrow/channel/187830-z-archived-t-compiler.2Fwg-profile-guided-optimization
 [parallel-rustc_stream]: https://rust-lang.zulipchat.com/#narrow/stream/187679-t-compiler.2Fwg-parallel-rustc
-[rfc-2229-stream]: https://rust-lang.zulipchat.com/#narrow/stream/189812-t-compiler.2Fwg-rfc-2229
-[mir-opt-stream]: https://rust-lang.zulipchat.com/#narrow/stream/189540-t-compiler.2Fwg-mir-opt
-[pipelining-stream]: https://rust-lang.zulipchat.com/#narrow/stream/195180-t-compiler.2Fwg-pipelining
+[rfc-2229-stream]: https://rust-lang.zulipchat.com/#narrow/channel/189812-z-archived-t-compiler.2Fwg-rfc-2229
+[mir-opts-stream]: https://rust-lang.zulipchat.com/#narrow/stream/189540-t-compiler.2Fwg-mir-opt
+[pipelining-stream]: https://rust-lang.zulipchat.com/#narrow/channel/195180-z-archived-t-compiler.2Fwg-pipelining
 [polonius_stream]: https://rust-lang.zulipchat.com/#narrow/channel/186049-t-types.2Fpolonius
-[polymorphization_stream]: https://rust-lang.zulipchat.com/#narrow/stream/216091-t-compiler.2Fwg-polymorphization
+[polymorphization_stream]: https://rust-lang.zulipchat.com/#narrow/channel/216091-z-archived-t-compiler.2Fwg-polymorphization
 [rustc-dev-guide_stream]: https://rust-lang.zulipchat.com/#narrow/stream/196385-t-compiler.2Fwg-rustc-dev-guide
 [Polonius]: https://github.com/rust-lang/polonius
-[diagnostics_stream]: https://rust-lang.zulipchat.com/#narrow/stream/147480-t-compiler.2Fwg-diagnostics
-[prioritization_stream]: https://rust-lang.zulipchat.com/#narrow/stream/227806-t-compiler.2Fwg-prioritization
+[diagnostics_stream]: https://rust-lang.zulipchat.com/#narrow/channel/147480-t-compiler.2Fdiagnostics
+[prioritization_stream]: https://rust-lang.zulipchat.com/#narrow/channel/227806-t-compiler.2Fprioritization

--- a/src/platforms/zulip.md
+++ b/src/platforms/zulip.md
@@ -105,7 +105,7 @@ starting out.
 ### Stream naming
 
 A stream should be named such as `#t-{team}/{group name}`. For example,
-`#t-compiler/wg-parallel-rustc`. More levels of nesting are fine, e.g., a
+`#t-compiler/parallel-rustc`. More levels of nesting are fine, e.g., a
 working group might want "subgroups" as well, though you may want to omit the
 team name in such a case -- keeping the stream name short is good for usability,
 to avoid confusion between different streams which share the same prefix.

--- a/src/triagebot/zulip-notifications.md
+++ b/src/triagebot/zulip-notifications.md
@@ -22,7 +22,7 @@ This feature is enabled on a repository by having a `[notify-zulip]` table in `t
 [notify-zulip."label-name"]
 # The Zulip stream to post to.
 # Can be found by looking for the first number in URLs, e.g. https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler
-zulip_stream = 245100 # #t-compiler/wg-prioritization/alerts
+zulip_stream = 245100 # #t-compiler/prioritization/alerts
 
 # The Zulip topic to post to.
 # {number} is replaced with the issue/PR number.


### PR DESCRIPTION
Updated the T-compiler names for Zulip archived channels

r? @davidtwco 

[Rendered](https://github.com/apiraino/rust-forge/blob/update-zulip-channels/src/compiler/notification-groups.md)