### PR TITLE
Add documentation for triagebot `[canonicalize-issue-links]` handler

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -16,6 +16,7 @@
     - [PR Assignment](./triagebot/pr-assignment.md)
     - [Tracking PR assignment](./triagebot/pr-assignment-tracking.md)
     - [Autolabels](./triagebot/autolabels.md)
+    - [Canonicalize Issue Links](./triagebot/canonicalize-issue-links.md)
     - [Close](./triagebot/close.md)
     - [Documentation Updates](./triagebot/doc-updates.md)
     - [GitHub Releases](./triagebot/github-releases.md)

--- a/src/triagebot/canonicalize-issue-links.md
+++ b/src/triagebot/canonicalize-issue-links.md
@@ -1,0 +1,17 @@
+# Canonicalize Issue Links
+
+GitHub permits having automatic action like `Fixes #123` which closes the issue number `123`, this handler updates the pull-request description with the canonicalized version, `Fixes org/repo#123`.
+
+This is useful when updating subtrees into the upstream repository as it avoids referencing and closing the issue from the upstream repository instead of the one from the subtree.
+
+## Configuration
+
+This feature is enabled on a repository by having a `[canonicalize-issue-links]` table in `triagebot.toml`:
+
+```toml
+[canonicalize-issue-links]
+```
+
+## Implementation
+
+See [`src/handlers/canonicalize_issue_links.rs`](https://github.com/rust-lang/triagebot/blob/HEAD/src/handlers/canonicalize_issue_links.rs).


### PR DESCRIPTION
Implemented in https://github.com/rust-lang/triagebot/pull/1897.

[Rendered](https://github.com/Urgau/rust-forge/blob/canonicalize-issue-links/src/SUMMARY.md)