### PR TITLE
Add documentation for triagebot `[no-mentions]` handler

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -26,6 +26,7 @@
     - [Mentions](./triagebot/mentions.md)
     - [Merge Conflicts](./triagebot/merge-conflicts.md)
     - [No Merge Policy](./triagebot/no-merge.md)
+    - [No Mentions](./triagebot/no-mentions.md)
     - [Nominate](./triagebot/nominate.md)
     - [Note](./triagebot/note.md)
     - [Notifications](./triagebot/notifications.md)

--- a/src/triagebot/no-mentions.md
+++ b/src/triagebot/no-mentions.md
@@ -1,0 +1,17 @@
+# No Mentions (in commits)
+
+GitHub permits having mentions (eg. `@user`) in commits, and while it's sometimes useful it almost always ends-up spamming the mentioned users, in particular as the commits are being rebased, cherry-picked or pushed.
+
+This handler tries to prevent those mentions by adding a comment warning in the PR against them.
+
+## Configuration
+
+This feature is enabled on a repository by having a `[no-mentions]` table in `triagebot.toml`:
+
+```toml
+[no-mentions]
+```
+
+## Implementation
+
+See [`src/handlers/check_commits/no_mentions.rs`](https://github.com/rust-lang/triagebot/blob/HEAD/src/handlers/check_commits/no_mentions.rs).


### PR DESCRIPTION
Implemented in https://github.com/rust-lang/triagebot/pull/1917

cc @Kobzol 

[Rendered](https://github.com/Urgau/rust-forge/blob/no-mentions/src/SUMMARY.md)