### PR TITLE
Rename triagebot `canonicalize-issue-links` to `issue-links`

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -21,6 +21,7 @@
     - [Documentation Updates](./triagebot/doc-updates.md)
     - [GitHub Releases](./triagebot/github-releases.md)
     - [Glacier](./triagebot/glacier.md)
+    - [Issue Links](./triagebot/issue-links.md)
     - [Issue Transfer](./triagebot/transfer.md)
     - [Labeling](./triagebot/labeling.md)
     - [Major Changes](./triagebot/major-changes.md)

--- a/src/triagebot/canonicalize-issue-links.md
+++ b/src/triagebot/canonicalize-issue-links.md
@@ -1,18 +1,3 @@
 # Canonicalize Issue Links
 
-GitHub permits having automatic action like `Fixes #123`, which closes the issue number `123`.
-This handler updates the pull-request description with the canonicalized version, `Fixes org/repo#123`.
-
-This is useful when updating subtrees into the upstream repository as it avoids referencing and closing the issue from the upstream repository instead of the one from the subtree.
-
-## Configuration
-
-This feature is enabled on a repository by having a `[canonicalize-issue-links]` table in `triagebot.toml`:
-
-```toml
-[canonicalize-issue-links]
-```
-
-## Implementation
-
-See [`src/handlers/canonicalize_issue_links.rs`](https://github.com/rust-lang/triagebot/blob/HEAD/src/handlers/canonicalize_issue_links.rs).
+This handler was renamed to `[issue-links]` see [Issue Links](issue-links.md).

--- a/src/triagebot/issue-links.md
+++ b/src/triagebot/issue-links.md
@@ -1,0 +1,24 @@
+# Issue Links
+
+## Canonicalise Issue Links
+
+GitHub permits having automatic action like `Fixes #123`, which closes the issue number `123`.
+This handler updates the pull-request description with the canonicalized version, `Fixes org/repo#123`.
+
+This is useful when updating subtrees into the upstream repository as it avoids referencing and closing the issue from the upstream repository instead of the one from the subtree.
+
+## Issue Links in Commits
+
+GitHub also permits having having issue links in commits which are then referenced in the issue. While useful, they often more than anything else spam the referenced issue. This handler puts a warning against them.
+
+## Configuration
+
+This feature is enabled on a repository by having a `[issue-links]` table in `triagebot.toml`:
+
+```toml
+[issue-links]
+```
+
+## Implementation
+
+See [`src/handlers/issue_links.rs`](https://github.com/rust-lang/triagebot/blob/HEAD/src/handlers/issue_links.rs) and [`src/handlers/check_commits/issue_links.rs`](https://github.com/rust-lang/triagebot/blob/HEAD/src/handlers/check_commits/issue_links.rs).


### PR DESCRIPTION
https://github.com/rust-lang/triagebot/pull/1932

[Rendered](https://github.com/Urgau/rust-forge/blob/issue-links/src/SUMMARY.md)