### PR TITLE
Add doc for triagebot [behind-upstream] handler

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -16,6 +16,7 @@
     - [PR Assignment](./triagebot/pr-assignment.md)
     - [Tracking PR assignment](./triagebot/pr-assignment-tracking.md)
     - [Autolabels](./triagebot/autolabels.md)
+    - [Behind Upstream](./triagebot/behind-upstream.md)
     - [Canonicalize Issue Links](./triagebot/canonicalize-issue-links.md)
     - [Close](./triagebot/close.md)
     - [Documentation Updates](./triagebot/doc-updates.md)

--- a/src/triagebot/behind-upstream.md
+++ b/src/triagebot/behind-upstream.md
@@ -1,12 +1,14 @@
 # Behind Upstream
 
-This is what happens when a PR's code is based on a very old commit from an upstream branch:
+This handler checks if a PR is based on an *X* days old commit.
+
+## Context
+
+When a PR's code is based on a very old commit from an upstream branch:
 It passes when tested locally, but fails when the PR is submitted for testing through CI.
 
 This is because the CI applies the commit patches to the current upstream branch,
 which may have new test cases, so it won't pass. We need to rebase the PR to the nearest upstream branch.
-
-This option checks if a PR is based on an older branch upstream.
 
 ## Configuration
 

--- a/src/triagebot/behind-upstream.md
+++ b/src/triagebot/behind-upstream.md
@@ -1,0 +1,26 @@
+# Behind Upstream
+
+This is what happens when a PR's code is based on a very old commit from an upstream branch:
+It passes when tested locally, but fails when the PR is submitted for testing through CI.
+
+This is because the CI applies the commit patches to the current upstream branch,
+which may have new test cases, so it won't pass. We need to rebase the PR to the nearest upstream branch.
+
+This option checks if a PR is based on an older branch upstream.
+
+## Configuration
+
+This feature is enabled on a repository by having a `[behind-upstream]` table in `triagebot.toml`:
+
+```toml
+[behind-upstream]
+```
+or, you can set the day threshold,
+```toml
+[behind-upstream]
+days-threshold = 7
+```
+
+## Implementation
+
+See [`src/handlers/check_commits/behind_upstream.rs`](https://github.com/rust-lang/triagebot/blob/HEAD/src/handlers/check_commits/behind_upstream.rs).

--- a/src/triagebot/behind-upstream.md
+++ b/src/triagebot/behind-upstream.md
@@ -12,6 +12,8 @@ which may have new test cases, so it won't pass. We need to rebase the PR to the
 
 ## Configuration
 
+> The default threshold is currently set at **7 days**.
+
 This feature is enabled on a repository by having a `[behind-upstream]` table in `triagebot.toml`:
 
 ```toml


### PR DESCRIPTION
Implemented in https://github.com/rust-lang/triagebot/pull/1942
r? @Urgau 

cc @Kobzol 

[Rendered](https://github.com/xizheyin/rust-forge/blob/behind-upstream/src/SUMMARY.md)