### PR TITLE
docs(policy): Clarify that Expatriation applies to all categories

### DIFF
--- a/src/policies/crate-ownership.md
+++ b/src/policies/crate-ownership.md
@@ -15,7 +15,7 @@ Rust crates published by the Rust project fall into one of the following categor
  - **Experiment**: This was an experiment by a team, intended to be picked up by users to better inform API design (or whatever), without a long-term commitment to maintainership. Example: [failure](https://crates.io/crates/failure)
  - **Deprecated**: This used to be an “intentional artifact” (or experiment/internal use) but isn’t anymore. Example: [rustc-serialize](https://crates.io/crates/rustc-serialize)
  - **Placeholder**: Not a functional crate, used for holding on to the name of an official tool, etc. Example: [rustup](https://crates.io/crates/rustup)
- - **Expatriated**: This may have been an “intentional artifact”, and still is intended to be used by external users, but is no longer intended to be official. In such cases the crate is no longer owned/managed by the Rust project. Example: [rand](https://crates.io/crates/rand)
+ - **Expatriated**: This may have been owned by the Rust Project and is still intended to be used by external users, but is no longer intended to be official. In such cases the crate is no longer owned/managed by the Rust project. Example: [rand](https://crates.io/crates/rand)
 
 ## Policy
 


### PR DESCRIPTION
The current wording makes it sound like Expatriation only applies to Intentional Artifacts but the Council recently clarified that it also applies to Experiments.

From [zulip](https://rust-lang.zulipchat.com/#narrow/channel/392734-council/topic/Crate.20Ownership.20Policy.20Clarification/near/513732109)

> Just to follow up here, the council discussed this today. Our
> interpretation was that expatriation requires an rfc and council
> approval regardless of its experimental or intentional status (and per
> the policy, is generally discouraged). It may be possible to achieve
> something similar by just forking the project and picking a new name,
> but it sounds like you don't want to go down that route. Working on it
> externally sounds like another alternative.

[Rendered](https://github.com/epage/rust-forge/blob/policy/src/policies/crate-ownership.md)