### PR TITLE
Add initial onboarding notes

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,6 +1,7 @@
 # Rust Forge
 
 [Overview](./README.md)
+- [Onboarding to the project](./onboarding.md)
 - [Platforms](./platforms/README.md)
   - [Twitter](./platforms/twitter.md)
   - [Discord](./platforms/discord.md)

--- a/src/onboarding.md
+++ b/src/onboarding.md
@@ -18,6 +18,7 @@ Moderation team.
 
 Escalating to the Council can be done via:
 
+- GitHub, via a [new issue](https://github.com/rust-lang/leadership-council/issues/new/choose). This will get discussed at the regular council meeting (to which all project members are [invited](https://github.com/rust-lang/leadership-council/blob/main/procedures/meeting-observers.md)).
 - Zulip, on [#council](https://rust-lang.zulipchat.com/#narrow/channel/392734-council).
 - Zulip DM, to your council representative (see
   [council](https://www.rust-lang.org/governance/teams/leadership-council) for

--- a/src/onboarding.md
+++ b/src/onboarding.md
@@ -29,7 +29,7 @@ comfortable with, though bias towards being public.
 Leadership Council positions are elected by the Project teams on a rotating
 calendar; see [Council term limits] for more details.
 
-[Council term limits]: https://rust-lang.github.io/rfcs/3392-leadership-council.html#term-limits
+[Council term limits]: governance/council.md#term-limits
 
 ## Relationship to Foundation
 

--- a/src/onboarding.md
+++ b/src/onboarding.md
@@ -1,0 +1,53 @@
+# Onboarding to the Project
+
+This document is a starting point for a new team member (or a refresh for
+existing team members) on things that are useful to know as a member of the
+project, in particular in terms of where to raise concerns or get help.
+
+## Relationship to Council
+
+The Leadership Council formally takes positions on behalf of the Project when
+needed. All Rust project members are officially represented by approximately
+one member of the council (some teams parent up to two or more members).
+
+Generally speaking, any concerns you have that are either more widely
+applicable (i.e., not just your team) or you feel aren't being fully handled
+within your team can be escalated to the Council. Note that interpersonal
+concerns and/or code of conduct violations should always be directed to the
+Moderation team.
+
+Escalating to the Council can be done via:
+
+- Zulip, on [#council](https://rust-lang.zulipchat.com/#narrow/channel/392734-council)
+- Zulip DM, to your council representative (see
+  [council](https://www.rust-lang.org/governance/teams/leadership-council) for
+  which team each representative represents).
+
+Either can be a reasonable starting point, please select what you feel more
+comfortable with, though bias towards being public.
+
+Leadership Council positions are elected by the Project teams on a rotating
+calendar, see [Council term limits] for more details.
+
+[Council term limits]: https://rust-lang.github.io/rfcs/3392-leadership-council.html#term-limits
+
+## Relationship to Foundation
+
+The Foundation works to support the project, and the project has direct
+representation on the Foundation's board (the 5 project directors). Those
+directors are selected by the Leadership Council per the [bylaws].
+
+Those directors have 50% of the vote on any Board vote in the Foundation,
+regardless of the number of non-Project directors.
+
+The website has the [current project directors].
+
+Please reach out whether you're just interested, have questions, or have concerns in:
+
+- Zulip, on [#foundation](https://rust-lang.zulipchat.com/#narrow/channel/335408-foundation)
+- To the Council (see above)
+- To one of the Project Directors (see member list above), recommending Zulip
+  DM as an initial point
+
+[current project directors]: https://www.rust-lang.org/governance/teams/launching-pad#team-foundation-board-project-directors
+[bylaws]: https://rustfoundation.org/policy/bylaws/#section-2.4-privileges-of-individual-membership

--- a/src/onboarding.md
+++ b/src/onboarding.md
@@ -18,7 +18,7 @@ Moderation team.
 
 Escalating to the Council can be done via:
 
-- Zulip, on [#council](https://rust-lang.zulipchat.com/#narrow/channel/392734-council)
+- Zulip, on [#council](https://rust-lang.zulipchat.com/#narrow/channel/392734-council).
 - Zulip DM, to your council representative (see
   [council](https://www.rust-lang.org/governance/teams/leadership-council) for
   which team each representative represents).
@@ -27,27 +27,27 @@ Either can be a reasonable starting point, please select what you feel more
 comfortable with, though bias towards being public.
 
 Leadership Council positions are elected by the Project teams on a rotating
-calendar, see [Council term limits] for more details.
+calendar; see [Council term limits] for more details.
 
 [Council term limits]: https://rust-lang.github.io/rfcs/3392-leadership-council.html#term-limits
 
 ## Relationship to Foundation
 
-The Foundation works to support the project, and the project has direct
-representation on the Foundation's board (the 5 project directors). Those
+The Foundation works to support the Project, and the Project has direct
+representation on the Foundation's board (the 5 Project directors). Those
 directors are selected by the Leadership Council per the [bylaws].
 
 Those directors have 50% of the vote on any Board vote in the Foundation,
 regardless of the number of non-Project directors.
 
-The website has the [current project directors].
+The website has the [current Project directors].
 
 Please reach out whether you're just interested, have questions, or have concerns in:
 
-- Zulip, on [#foundation](https://rust-lang.zulipchat.com/#narrow/channel/335408-foundation)
-- To the Council (see above)
+- Zulip, on [#foundation](https://rust-lang.zulipchat.com/#narrow/channel/335408-foundation).
+- To the Council (see above).
 - To one of the Project Directors (see member list above), recommending Zulip
-  DM as an initial point
+  DM as an initial point.
 
-[current project directors]: https://www.rust-lang.org/governance/teams/launching-pad#team-foundation-board-project-directors
+[current Project directors]: https://www.rust-lang.org/governance/teams/launching-pad#team-foundation-board-project-directors
 [bylaws]: https://rustfoundation.org/policy/bylaws/#section-2.4-privileges-of-individual-membership


### PR DESCRIPTION
The lack of this came up in discussion during an all-hands session as a missing artifact. I'm not sure whether this should be in the Forge (but where else?) but seems like an OK starting point. Also probably much more than just this would be helpful.

cc @rust-lang/leadership-council @carols10cents @JakobDegen @rylev @scottmcm @spastorino

[Rendered](https://github.com/Mark-Simulacrum/rust-forge/blob/onboarding-guide/src/SUMMARY.md)