### PR TITLE
Document compiler backport nomination/review process

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -55,6 +55,7 @@
     - [Review Policy](./compiler/reviews.md)
     - [Proposals, Approval and Stabilization](./compiler/proposals-and-stabilization.md)
         - [Adding ecosystem/integration test jobs/components to `rust-lang/rust` CI](./compiler/proposals-and-stabilization/ecosystem-integration-tests.md)
+    - [Backports](./compiler/backports.md)
     - [Third-party and Out-of-tree Crates Policy](./compiler/third-party-out-of-tree.md)
     - [Triage and Prioritization](./compiler/prioritization.md)
     - [Working Areas](./compiler/working-areas.md)

--- a/src/compiler/README.md
+++ b/src/compiler/README.md
@@ -6,6 +6,13 @@ We use the Forge to document the team's processes, policies and working practice
 read about how the compiler works and instructions on how to set up a development environment,
 you're looking for the [rustc-dev-guide](https://rustc-dev-guide.rust-lang.org/).
 
+<!--
+NOTE: please keep the following alphabetically sorted.
+-->
+
+- [Backports](./backports.md)
+  - *How do I request a beta and/or stable backport of a compiler change? How will compiler 
+    backport nominations be handled?*
 - [Calendar](./calendar.md)
   - *How do I subscribe to the compiler team's calendar?*
 - [Cross-team Collaboration](./cross-team-collaboration.md)
@@ -14,20 +21,20 @@ you're looking for the [rustc-dev-guide](https://rustc-dev-guide.rust-lang.org/)
   - *What meetings do the compiler team run and how can I attend?*
 - [Membership](./membership.md)
   - *What is expected of compiler team members and how do I join?*
+- [Proposals, Approval and Stabilization](./proposals-and-stabilization.md)
+  - *How do I propose a change to the compiler team? What approval is necessary for my change?*
+- [Repositories we maintain](https://github.com/orgs/rust-lang/teams/compiler/repositories)
+  - *Various code repositories maintained by the Compiler Team*
 - [Resources](./resources.md)
   - *What useful resources are available for contributors and team members?*
 - [Review Policy](./reviews.md)
   - *How do I make a contribution which is easy to review? How do I start reviewing as a team member?*
-- [Proposals, Approval and Stabilization](./proposals-and-stabilization.md)
-  - *How do I propose a change to the compiler team? What approval is necessary for my change?*
 - [Third-party and Out-of-tree Crates Policy](./third-party-out-of-tree.md)
   - *When can I add third-party crates to the compiler? When can I create a out-of-tree crate for
      the compiler?*
 - [Triage and Prioritization](./prioritization.md)
   - *How are compiler issues triaged and prioritized?*
-- [Working Areas](./working-areas.md)
-  - *Specific areas of work around the compiler*
-- [Repository we maintain](https://github.com/orgs/rust-lang/teams/compiler/repositories)
-  - *Various code repositories maintained by the Compiler Team*
 - [Operations](./operations.md)
   - *Supporting the compiler team*
+- [Working Areas](./working-areas.md)
+  - *Specific areas of work around the compiler*

--- a/src/compiler/backports.md
+++ b/src/compiler/backports.md
@@ -1,0 +1,90 @@
+# Backports
+
+Sometimes compiler fixes need to be backported to the stable and/or beta channel to fix a
+significant regression or to revert unintentional changes that weren't noticed when originally
+merged. See also [prioritization](./prioritization.md) for how priority of issues and regressions
+are determined.
+
+In case a backport is applied to the stable channel, the Rust project will release a patch release
+(for example a 1.87.1 point release could follow the initial stable release 1.87.0).
+
+## Nominating for backport review
+
+You can propose a change be backported by applying labels to the GitHub pull request. Add
+`beta-nominated` if the patch should be backported to the **beta** channel, and also
+`stable-nominated` if it needs backported to the **stable** channel. Make sure the pull request has
+a [`T-compiler`] label as well.
+
+In any case, you should **add a comment when you nominate the pull request for backport** providing
+context for the compiler team backport reviewers about why it should be backported.
+
+**Backport nominations are not guaranteed be accepted**. Please refer to the [*Should the backport
+be approved*](#should-the-backport-be-approved) section below for the criteria on which backport
+nominations may be accepted or rejected.
+
+Beta regressions that slid to the stable channel will need a stable backport nomination (and a
+subsequent patch release, if approved).
+
+The compiler team tries to make sure that critical issues (labeled with `P-critical`) do not
+progress to the stable release.
+
+## Reviewing compiler backport nominations
+
+When one of [`beta-nominated`] or [`stable-nominated`] label is applied, a new thread is
+automatically opened on Zulip in the [#t-compiler/backports] channel. Compiler team members can use
+these Zulip threads to cast their vote asynchronously in favor of or raise concerns about
+backporting. If you are a compiler team member and want to be notified of these threads, you should
+subscribe that zulip channel.
+
+During the weekly triage meeting (happening on [#t-compiler/meetings], see [here](./meetings.md)),
+the compiler team will finalize the decision and apply the relevant `{beta,stable}-accepted` label.
+
+### Should the backport be approved?
+
+For compiler backport reviewers, here are some **non-exhaustive** considerations that they might
+consider in making a backport decision:
+
+- The nominated change is not merged in time for the stable or beta release channel (e.g. due to
+  implementation issues).
+- Has the backport enough time to be tested?
+  - (For beta backport nominations) The nominated change would be applied too close to the next
+    stable compiler release. Merging a backport at this time will mean very limited (if any) time
+    for testing.
+  - A stable point release will be *immediately* available to all users without any time to bake!
+- How complex or risky is the nominated compiler change? Is the risk of the backport introducing new
+  regressions potentially worse than the regression or issue it addresses?
+- How severe is the regression/issue being fixed?
+  - For example stable regressions are not all equal: some are not very severe or are already on
+    stable channel since multiple releases.
+
+By default, approved stable backports will cause a new point release to be issued by the [release
+team](../release/backporting.md#stable-backporting-in-rust-langrust).
+
+However, the compiler team may approve a stable backport, but additionally indicate to the [release
+team](../release/backporting.md) that the nomination does not justify a stable point release *on its
+own*. In this case, the release team will consider other approved stable backport candidates and how
+serious those are in conjunction with this candidate, to finalize a decision on whether to execute a
+stable point release.
+
+## How are approved backports handled?
+
+The [release team](../release/README.md) (`T-release`) will handle the backport at the end of the
+current development cycle (see [release backporting](../release/backporting.md)). If a beta backport
+nomination is approved too late, the release team may be unable to backport the change.
+
+Most of the time, accepted backports target the `master` branch. In rare circumstances, a beta
+backport may need to *directly* target the `beta` branch. In this case, coordinate with the release
+team before merging, by opening a new thread on the Zulip [#t-release
+channel](https://rust-lang.zulipchat.com/#narrow/channel/241545-t-release)).
+
+For complicated backports, the release team may ask the patch author for assistance.
+
+
+[`beta-nominated`]: https://github.com/rust-lang/rust/labels/beta-nominated
+[`beta-accepted`]: https://github.com/rust-lang/rust/labels/beta-accepted
+[`stable-nominated`]: https://github.com/rust-lang/rust/labels/stable-nominated
+[`stable-accepted`]: https://github.com/rust-lang/rust/labels/stable-accepted
+[#t-compiler/backports]:
+    https://rust-lang.zulipchat.com/#narrow/channel/474880-t-compiler.2Fbackports
+[#t-compiler/meetings]: https://rust-lang.zulipchat.com/#narrow/channel/238009-t-compiler.2Fmeetings
+[`T-compiler`]: https://github.com/rust-lang/rust/labels/T-compiler

--- a/src/compiler/proposals-and-stabilization.md
+++ b/src/compiler/proposals-and-stabilization.md
@@ -334,6 +334,10 @@ circumstance.
   - **Approve using:** r+ (compiler leads)
   - Open a PR with the change affecting licensing and assign it to the team leads for review
 
+### Stable/beta channel backport nominations of compiler changes
+
+See [*Backports*](./backports.md).
+
 ### Adding ecosystem/integration test jobs/components to rust-lang/rust CI
 
 See [*Adding ecosystem/integration test jobs/components to rust-lang/rust CI*](./proposals-and-stabilization/custom-test-jobs.md).


### PR DESCRIPTION
> [!TIP]
>
> Part of a meta-effort to document our team policies and processes, cf. [#all-hands-2025 > team processes and policies session](https://rust-lang.zulipchat.com/#narrow/channel/486433-all-hands-2025/topic/team.20processes.20and.20policies.20session/with/519137687).

As part of the async compiler backport experiment, I noticed we didn't really have any concrete docs on how compiler handles backport nominations and decisions (esp. the async process that we're experimenting with now, but also the sync process).

This PR intentionally leaves out specific approvals thresholds because those are still subject to experimentation.

r? @davidtwco (and @wesleywiser)
cc @apiraino (compiler-ops 😁)
cc @cuviper (since you raised the "it's hard (for release team) to determine when to know compiler has reached a backport decision" point with me :D)
cc @rust-lang/release 

[Rendered](https://github.com/jieyouxu/rust-forge/blob/compiler-async-backport/src/SUMMARY.md)