### PR TITLE
Add documentation for triagebot `concern` command

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -20,6 +20,7 @@
     - [Behind Upstream](./triagebot/behind-upstream.md)
     - [Canonicalize Issue Links](./triagebot/canonicalize-issue-links.md)
     - [Close](./triagebot/close.md)
+    - [Concern](./triagebot/concern.md)
     - [Documentation Updates](./triagebot/doc-updates.md)
     - [GitHub Releases](./triagebot/github-releases.md)
     - [Issue Links](./triagebot/issue-links.md)

--- a/src/triagebot/concern.md
+++ b/src/triagebot/concern.md
@@ -16,7 +16,7 @@ The concern is then added in the top comment of the GitHub issue to a special se
 
 ### Resolving a concern
 
-Concerns can be resolved by writing a comment with command:
+Concerns can be resolved by writing a comment with the command:
 
 ```text
 @rustbot resolve my concern title
@@ -30,7 +30,7 @@ This feature is enabled by having a `[concern]` table in `triagebot.toml`:
 
 ```toml
 [concern]
-labels = ["has-concerns"] # optional, list of labels automaticaly when there are un-resolved concerns
+labels = ["has-concerns"] # optional, list of labels to be added to the issue/PR when there are un-resolved concerns
 ```
 
 ## Implementation

--- a/src/triagebot/concern.md
+++ b/src/triagebot/concern.md
@@ -1,0 +1,38 @@
+# Concern
+
+The `concern` command is used to formally register a concern at the top comment of a GitHub issue/PR.
+
+## Usage
+
+A concern can be registered by writing a comment with the command:
+
+```text
+@rustbot concern my concern title
+```
+
+The concern is then added in the top comment of the GitHub issue to a special section: `Concerns` (which should *not* be edited by hand).
+
+*Concerns can only be registered by member of the organization and cannot be registered on active [rfcbot FCPs](https://rfcbot.rs).*
+
+### Resolving a concern
+
+Concerns can be resolved by writing a comment with command:
+
+```text
+@rustbot resolve my concern title
+```
+
+The concern is then strikethrough and a link to the comment resolving the concern is added next to it.
+
+## Configuration
+
+This feature is enabled by having a `[concern]` table in `triagebot.toml`:
+
+```toml
+[concern]
+labels = ["has-concerns"] # optional, list of labels automaticaly when there are un-resolved concerns
+```
+
+## Implementation
+
+See [`parser/src/command/concern.rs`](https://github.com/rust-lang/triagebot/blob/HEAD/parser/src/command/concern.rs) and [`src/handlers/concern.rs`](https://github.com/rust-lang/triagebot/blob/HEAD/src/handlers/concern.rs).


### PR DESCRIPTION
Related to https://github.com/rust-lang/triagebot/pull/2022.

[Rendered](https://github.com/Urgau/rust-forge/blob/triagebot-concern/src/SUMMARY.md)