### PR TITLE
Use actions/deploy-pages to deploy the website

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,34 +8,44 @@ on:
       - master
 
 jobs:
-  ci:
-    name: CI
-    runs-on: ubuntu-latest
+  build:
     env:
       MDBOOK_VERSION: 0.4.51
-    permissions:
-      id-token: write
-      contents: write
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install mdbook
         run: curl -sSL https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz | tar -xz
       - name: Check blacksmith format
         run: cargo fmt --check --manifest-path=blacksmith/Cargo.toml
       - name: Build book
         run: ./mdbook build
-      - name: Deploy book
-        uses: rust-lang/simpleinfra/github-actions/static-websites@master
+      - name: Upload artifact
+        if: github.ref == 'refs/heads/master'
+        uses: actions/upload-pages-artifact@v3
         with:
-          deploy_dir: book
-          github_token: "${{ secrets.GITHUB_TOKEN }}"
-        if: github.ref == 'refs/heads/master'
+          path: ./book
+
+  deploy:
+    if: github.ref == 'refs/heads/master' && github.repository_owner == 'rust-lang'
+    needs: build
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@4
       - name: Configure AWS credentials
-        if: github.ref == 'refs/heads/master'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: arn:aws:iam::890664054962:role/forge-rust-lang-org-ci
           aws-region: us-east-1
       - name: Invalidate CloudFront cache
         run: aws cloudfront create-invalidation --distribution-id E12A3GKHZSREHP --paths "/*"
-        if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
This switches from rust-lang/simpleinfra/github-actions/static-websites to using GitHub's native actions/deploy-pages to deploy the site. The deploy part of static-websites doesn't seem to be getting updated, and by the discussion at https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Remove.20static-websites.20GitHub.20Action/with/474632056 I get the impression that the infra team would prefer to retire it.

r? marcoieni 
Since you seem to have some context here.

**I think this will need settings changes before merging.** IIUC, static-websites was deploying to a branch, but deploy-pages changes the source. In `Settings > Pages > Build and Deployment > Source` I think the source needs to be changed to "GitHub Actions", though check my understanding since I am uncertain.
