### PR TITLE
Update and fix MCPs commands

### DIFF
--- a/src/compiler/proposals-and-stabilization.md
+++ b/src/compiler/proposals-and-stabilization.md
@@ -79,7 +79,7 @@ Zulip). See the previous section. To facilitate a machine parsable scanning of t
 please use the following syntax to formally register a concern:
 
 ```
-@rfcbot concern reason-for-concern
+@rustbot concern reason-for-concern
 
 <long description of the concern>
 ```
@@ -87,13 +87,13 @@ please use the following syntax to formally register a concern:
 And the following syntax to lift a concern when resolved:
 
 ```
-@rfcbot resolve reason-for-concern
+@rustbot resolve reason-for-concern
 ```
 
 MCPs can be seconded using:
 
 ```
-@rfcbot second
+@rustbot second
 ```
 
 ##### Who decides whether a concern is unresolved?


### PR DESCRIPTION
This PR updates the `concern` and `resolve` commands in the MCP section to use `@rustbot` instead, as per https://github.com/rust-lang/compiler-team/pull/880

This also fix the `second` command which was wrongly under `rfcbot`.

r? @apiraino 

[Rendered](https://github.com/Urgau/rust-forge/blob/mcp-update-commands/src/compiler/proposals-and-stabilization.md)