### PR TITLE
Clarify that T-compiler meetings are text-mode only

### DIFF
--- a/src/compiler/meetings.md
+++ b/src/compiler/meetings.md
@@ -2,12 +2,13 @@
 The compiler team host various regular meetings to keep on top of regular business necessary for
 the running of the team and delivery of a high-quality compiler toolchain.
 
+All the T-compiler meetings are held in our Zulip chat [`#t-compiler/meetings`][meetings_channel],
+in text-mode only.
+
 ## Triage Meeting
-The weekly triage meeting takes place on Zulip: considering any backports, reviewing
-performance triage reports and discussing nominated issues. Triage meetings are held in the
-[`#t-compiler/meetings`][meetings_channel] on Zulip. You can find the up-to-date meeting times in
-[the team calendar](./calendar.md). Anyone can attend and it is recommended that compiler team
-members do.
+During the weekly triage meeting the team considers backports, reviews performance triage reports
+and discusses nominated issues. You can find the up-to-date meeting times in [the team
+calendar](./calendar.md). Anyone can attend and it is recommended that compiler team members do.
 
 Agendas of triage meetings are stored on [HackMD][meeting_triage_notes].
 
@@ -16,8 +17,8 @@ See [*Prioritization*](./prioritization.md) for documentation on generating the 
 agenda.
 
 ## Steering/Planning Meeting
-The weekly steering/planning meeting also takes place on Zulip and is intended to host high-level
-discussions. Steering/planning meetings operate on a repeating schedule:
+At a regular cadence, the team also meets to discuss high-level topics. Steering/planning meetings
+operate on a repeating schedule:
 
 - **Week 1:** Planning meeting
   - Select the topics for the next three meetings from the team's proposed meetings.

--- a/src/compiler/prioritization.md
+++ b/src/compiler/prioritization.md
@@ -195,9 +195,8 @@ After the meeting, there are a few closing tasks:
   commit the agenda as minutes to the `compiler-team` repository.
 - Remove the `to-announce` label from [MCPs][mcps], unless this label was added exactly during
   the meeting (and therefore will be seen during the following meeting).
-- Remove `to-announce` FCPs from [`rust-lang/rust` repo][announce], [`compiler-team`
-  repo][team_announce] and [forge repo][forge_announce]. Same disclaimer as before regarding changes
-  during the meeting.
+- Remove `to-announce` FCPs from [`rust-lang/rust`][rust_announce], [`compiler-team`][team_announce]
+  and the [forge][forge_announce]. Same disclaimer as before regarding changes during the meeting.
 - Accept or decline [`beta nominated`][beta_nominated] and [`stable nominated`][beta_nominated]
   backports that have been accepted during the meeting. For more info check [`t-release` backporting
   docs][release_backports]


### PR DESCRIPTION
From comment: https://github.com/rust-lang/rust-forge/issues/865#issuecomment-2949283516

> The fact that the compiler meetings are purely textual (i.e. without voice / video chat) was strange enough to me that I kept looking for a Google Meet link, even though the docs stated fairly clearly that meetings happen on Zulip.



[Rendered](https://github.com/apiraino/rust-forge/blob/clarify-t-compiler-meetings/src/compiler/meetings.md)