### PR TITLE
Fix link to MCP

### DIFF
--- a/src/triagebot/major-changes.md
+++ b/src/triagebot/major-changes.md
@@ -1,6 +1,6 @@
 # Major Changes
 
-Triagebot helps with automated processing of [Major Change Proposals](../compiler/mcp.md).
+Triagebot helps with automated processing of [Major Change Proposals](../compiler/proposals-and-stabilization.md#how-do-i-submit-an-mcp).
 
 ## Usage
 


### PR DESCRIPTION
I think that we have a bunch of broken links in the Forge. What do you think about enabling (intra-doc, not external URL) linkchecking on CI?