### PR TITLE
Fix deploy path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./book
+          path: ./book/html
 
   deploy:
     if: github.repository_owner == 'rust-lang'


### PR DESCRIPTION
When adding the linkchecker renderer, that changed mdbook to give each renderer a separate path.