### PR TITLE
Extend guide for configuring legacy AWS access

### DIFF
--- a/src/infra/docs/aws-access.md
+++ b/src/infra/docs/aws-access.md
@@ -48,9 +48,14 @@ account.
 The [AWS CLI](https://aws.amazon.com/cli/) allows you to interact with our AWS
 account from a terminal or a script. To set it up the first time, follow
 Amazon's documentation to [install it][awscli-install] and [configure your
-credentials][awscli-configure]. The CLI doesn't use your console password to
+credentials][awscli-configure].
+
+The CLI doesn't use your console password to
 authenticate: you'll need to create an access key from the "My Security
 Credentials" page on the console.
+
+After you do that, run `aws configure` and paste the access key ID and the secret
+key from the console to configure it. Use `us-west-1` as the default region.
 
 ### 2-factor authentication
 


### PR DESCRIPTION
I struggled with this today, so tried to make docs be in a bit better state than I found them :laughing:

[Rendered](https://github.com/Kobzol/rust-forge/blob/aws-configure/src/infra/docs/aws-access.md)