### PR TITLE
readme: be a little less formal

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -2,10 +2,10 @@
 Welcome to the Rust Forge! Rust Forge serves as a repository of supplementary
 documentation useful for members of [The Rust Programming Language]. If
 you find any mistakes, typos, or want to add to the Rust Forge, feel free to
-file an issue or PR on the [Rust Forge GitHub].
+file an issue or PR [on GitHub].
 
 [The Rust Programming Language]: https://rust-lang.org
-[Rust Forge GitHub]: https://github.com/rust-lang/rust-forge
+[on GitHub]: https://github.com/rust-lang/rust-forge
 
 ### Help Wanted
 


### PR DESCRIPTION
was thinking of fixing this to say _on Rust Forge GitHub repo_, but then thought lighter wording sounds even better

[Rendered](https://github.com/tshepang/rust-forge/blob/patch-5/src/README.md)