### PR TITLE
Enable blacksmith global artifact caching

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$PWD"/target}
-export CARGO_TARGET_DIR
-
 if [ "${RUN_BLACKSMITH:-0}" = "1" ]; then
   cargo run --locked --manifest-path=blacksmith/Cargo.toml -- "$@"
 else


### PR DESCRIPTION
`cargo` can now autoconfigure a global build cache either by reading:
- `$CARGO_TARGET_DIR`
- A config file in `~/.cargo`

This entered in a "call for testing" phase recently, see [Twir #602](https://this-week-in-rust.org/blog/2025/06/04/this-week-in-rust-602/#calls-for-testing), so it's available on stable.

The manual override in the build script is not necessary anymore. Instead - it now *prevents* using the global cache in a configuration where `CARGO_TARGET_DIR` is not set but configured in the global cargo config.