### PR TITLE
Rename test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   test:
-    name: CI
+    name: test
     runs-on: ubuntu-latest
     env:
       MDBOOK_VERSION: 0.4.51


### PR DESCRIPTION
This renames the test job to "test" which I think is more descriptive, and also matches the new required-ci checks name.

This fixes merging which no longer works due to https://github.com/rust-lang/team/pull/1870.