### PR TITLE
Adjust width of page nav buttons to avoid hiding the code block clip buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,3 +1,8 @@
 :root {
     --content-max-width: 1000px;
 }
+
+.nav-chapters {
+    max-width: 75px;
+    min-width: 45px;
+}


### PR DESCRIPTION
Since #894 was applied, it has been difficult to access the code clip buttons.
When I move the cursor from the lower left direction of the button, the next page navigation button covers the button before I reach it, as screenshots below shows.
(When I move the cursor from almost directly left of the button, I can reach it.)

This PR fixes that issue by reducing the width of the page navigation buttons.
I hope you will apply it if you like it.

<img width="160" height="161" alt="ss 2025-07-15 14 25 41" src="https://github.com/user-attachments/assets/dbf915f0-1173-4407-b6f8-d074905df20e" />
<img width="160" height="161" alt="ss 2025-07-15 14 26 00" src="https://github.com/user-attachments/assets/131a069e-c704-43ee-a73f-bc810c473d99" />
