### PR TITLE
Fix tests by adding markdown tags

### DIFF
--- a/src/compiler/prioritization.md
+++ b/src/compiler/prioritization.md
@@ -157,7 +157,7 @@ Finally, the meeting agenda can be generated. Clone and build [`triagebot`][tria
 
 [triagebot]: https://github.com/rust-lang/triagebot
 
-```
+```console
 $ cargo run --bin prioritization-agenda
 ```
 

--- a/src/compiler/proposals-and-stabilization.md
+++ b/src/compiler/proposals-and-stabilization.md
@@ -83,7 +83,7 @@ These types of procedural comments can be left on the issue (it's also good to l
 Zulip). See the previous section. To facilitate a machine parsable scanning of the concerns
 please use the following syntax to formally register a concern:
 
-```
+```text
 @rustbot concern reason-for-concern
 
 <long description of the concern>
@@ -91,13 +91,13 @@ please use the following syntax to formally register a concern:
 
 And the following syntax to lift a concern when resolved:
 
-```
+```text
 @rustbot resolve reason-for-concern
 ```
 
 MCPs can be seconded using:
 
-```
+```text
 @rustbot second
 ```
 

--- a/src/crates-io/crate-removal.md
+++ b/src/crates-io/crate-removal.md
@@ -12,11 +12,15 @@ whether we have to comply with it.
 
 * Remove it from the database:
 
-      heroku run -a crates-io -- target/release/crates-admin delete-crate [crate-name]
+  ```console
+  heroku run -a crates-io -- target/release/crates-admin delete-crate [crate-name]
+  ```
 
   or
 
-      heroku run -a crates-io -- target/release/crates-admin delete-version [crate-name] [version-number]
+  ```console
+  heroku run -a crates-io -- target/release/crates-admin delete-version [crate-name] [version-number]
+  ```
 
 * Remove the crate or version from the index. To remove an entire crate, remove
   the entire crate file. For a version, remove the line corresponding to the
@@ -26,7 +30,7 @@ whether we have to comply with it.
 
 * Invalidate the CloudFront cache:
 
-  ```
+  ```console
   aws cloudfront create-invalidation --distribution-id EJED5RT0WA7HA --paths '/*'
   ```
 

--- a/src/crates-io/db-maintenance.md
+++ b/src/crates-io/db-maintenance.md
@@ -41,7 +41,7 @@ can use:
 
 2. Scale the background worker to 0 instances:
 
-   ```
+   ```console
    heroku ps:scale -a crates-io background_worker=0
    ```
 
@@ -58,7 +58,7 @@ can use:
 
 3. Configure the application to be in read-only mode without the follower:
 
-   ```
+   ```console
    heroku config:set -a crates-io READ_ONLY_MODE=1 DB_OFFLINE=follower
    ```
 
@@ -69,37 +69,37 @@ can use:
 
 3. Wait for the application to be redeployed with the new configuration:
 
-    ```
+    ```console
     heroku ps:wait -a crates-io
     ```
 
 3. Run the database maintenance:
 
-   ```
+   ```console
    heroku pg:maintenance:run --force -a crates-io
    ```
 
 1. Wait for the maintenance to finish:
 
-    ```
+    ```console
     heroku pg:wait -a crates-io
     ```
 
 3. Confirm all the databases are online:
 
-   ```
+   ```console
    heroku pg:info -a crates-io
    ```
 
 3. Confirm the primary database fully recovered (should output `false`):
 
-   ```
+   ```console
    echo "SELECT pg_is_in_recovery();" | heroku pg:psql -a crates-io DATABASE
    ```
 
 3. Switch off read-only mode:
 
-   ```
+   ```console
    heroku config:unset -a crates-io READ_ONLY_MODE
    ```
 
@@ -110,7 +110,7 @@ can use:
 
 3. Wait for the application to be redeployed with the new configuration:
 
-    ```
+    ```console
     heroku ps:wait -a crates-io
     ```
 
@@ -124,19 +124,19 @@ can use:
 
 3. Scale the background worker up again:
 
-   ```
+   ```console
    heroku ps:scale -a crates-io background_worker=1
    ```
 
 3. Confirm the follower database is available:
 
-   ```
+   ```console
    echo "SELECT 1;" | heroku pg:psql -a crates-io READ_ONLY_REPLICA
    ```
 
 3. Enable connections to the follower:
 
-   ```
+   ```console
    heroku config:unset -a crates-io DB_OFFLINE
    ```
 
@@ -156,48 +156,48 @@ load by doing this.
 
 1. Configure the application to operate without the follower:
 
-    ```
+    ```console
     heroku config:set -a crates-io DB_OFFLINE=follower
     ```
 
 1. Wait for the application to be redeployed with the new configuration:
 
-    ```
+    ```console
     heroku ps:wait -a crates-io
     ```
 
 1. Start the database maintenance:
 
-    ```
+    ```console
     heroku pg:maintenance:run --force -a crates-io READ_ONLY_REPLICA
     ```
 
 1. Wait for the maintenance to finish:
 
-    ```
+    ```console
     heroku pg:wait -a crates-io READ_ONLY_REPLICA
     ```
 
 1. Confirm the follower database is ready:
 
-    ```
+    ```console
     heroku pg:info -a crates-io
     ```
 
 1. Confirm the follower database is responding to queries:
 
-    ```
+    ```console
     echo "SELECT 1;" | heroku pg:psql -a crates-io READ_ONLY_REPLICA
     ```
 
 1. Enable connections to the follower:
 
-    ```
+    ```console
     heroku config:unset -a crates-io DB_OFFLINE
     ```
 
 1. Wait for the application to be redeployed with the new configuration.
 
-    ```
+    ```console
     heroku ps:wait -a crates-io
     ```

--- a/src/docs-rs/maintenance.md
+++ b/src/docs-rs/maintenance.md
@@ -7,20 +7,20 @@ clogging up the queue and preventing other crates to build. In this case it's
 possible to temporarily remove the crate from the queue until the docs.rs's bug
 is fixed. To do that, log into the machine and open a PostgreSQL shell with:
 
-```
+```console
 $ psql
 ```
 
 Then you can run this SQL query to remove the crate:
 
-```
+```psql
 UPDATE queue SET attempt = 100 WHERE name = '<CRATE_NAME>';
 ```
 
 To add the crate back in the queue you can run in the PostgreSQL shell this
 query:
 
-```
+```psql
 UPDATE queue SET attempt = 0 WHERE name = '<CRATE_NAME>';
 ```
 
@@ -32,13 +32,13 @@ nightly and instead pin a specific release. To do that you need to edit the
 `/home/cratesfyi/.docs-rs-env` file, adding or changing this environment
 variable:
 
-```
+```console
 CRATESFYI_TOOLCHAIN=nightly-YYYY-MM-DD
 ```
 
 Once the file changed docs.rs needs to be restarted:
 
-```
+```console
 systemctl restart docs.rs
 ```
 
@@ -50,7 +50,7 @@ restart docs.rs again.
 If a bug was recently fixed, you may want to rebuild a crate so that it builds with the latest version.
 From the docs.rs machine:
 
-```
+```console
 cratesfyi queue add <crate> <version>
 ```
 
@@ -109,14 +109,14 @@ cratesfyi=> UPDATE queue SET priority = 1 WHERE name LIKE 'group-%';
 After an outage you might want to add all the failed builds back to the queue.
 To do that, log into the machine and open a PostgreSQL shell with:
 
-```
+```console
 psql
 ```
 
 Then you can run this SQL query to add all the crates failed after `YYYY-MM-DD
 HH:MM:SS` back in the queue:
 
-```
+```psql
 UPDATE queue SET attempt = 0 WHERE attempt >= 5 AND build_time > 'YYYY-MM-DD HH:MM:SS';
 ```
 
@@ -126,7 +126,7 @@ Sometimes it might be needed to remove all the content related to a crate from
 docs.rs (for example after receiving a DMCA). To do that, log into the server
 and run:
 
-```
+```console
 cratesfyi database delete-crate CRATE_NAME
 ```
 
@@ -139,7 +139,7 @@ Occasionally it might be needed to prevent a crate from being built on docs.rs,
 for example if we can't legally host the content of those crates. To add a
 crate to the blacklist, preventing new builds for it, you can run:
 
-```
+```console
 cratesfyi database blacklist add <CRATE_NAME>
 ```
 

--- a/src/docs-rs/self-hosting.md
+++ b/src/docs-rs/self-hosting.md
@@ -73,7 +73,7 @@ To help contain what crates' build scripts can access, documentation builds run 
 
 You'll also need to configure networking for the container. The following is a sample `/etc/default/lxc-net` that enables NAT networking for the container:
 
-```
+```console
 USE_LXC_BRIDGE="true"
 LXC_BRIDGE="lxcbr0"
 LXC_ADDR="10.0.3.1"
@@ -87,7 +87,7 @@ LXC_DOMAIN=""
 
 In addition, you'll need to set the container's configuration to use this. Add the following lines to `/cratesfyi-prefix/cratesfyi-container/config`:
 
-```
+```console
 lxc.net.0.type = veth
 lxc.net.0.link = lxcbr0
 ```
@@ -132,7 +132,7 @@ To ensure that the docs.rs server is configured properly, we need to set a few e
 
 Write the following into `/home/cratesfyi/.cratesfyi.env`. If you have a GitHub access token that the site can use to collect repository information, add it here, but otherwise leave it blank. The variables need to exist, but they can be blank to skip that collection.
 
-```
+```console
 CRATESFYI_PREFIX=/cratesfyi-prefix
 CRATESFYI_DATABASE_URL=postgresql://cratesfyi:password@localhost
 CRATESFYI_CONTAINER_NAME=cratesfyi-container

--- a/src/infra/docs/aws-access.md
+++ b/src/infra/docs/aws-access.md
@@ -69,7 +69,7 @@ To use the script, clone the [rust-lang/simpleinfra][simpleinfra] repository in
 a directory. Then, every time you need to use the AWS CLI run this command in
 your shell:
 
-```
+```console
 eval $(~/PATH/TO/SIMPLEINFRA/aws-creds.py)
 ```
 

--- a/src/infra/docs/bastion.md
+++ b/src/infra/docs/bastion.md
@@ -16,7 +16,7 @@ To log into a server through the bastion, use one of the following methods:
 
 - Use SSH's `-J` flag:
 
-  ```
+  ```console
   ssh -J <username>@bastion.infra.rust-lang.org <username>@servername.infra.rust-lang.org
   ```
 
@@ -24,14 +24,14 @@ To log into a server through the bastion, use one of the following methods:
 
   - Add this snippet to your SSH configuration file (usually located in `~/.ssh/config`):
 
-    ```
+    ```console
     Host servername.infra.rust-lang.org
         ProxyJump <username>@bastion.infra.rust-lang.org
     ```
 
   - Use SSH:
 
-    ```
+    ```console
     ssh <username>@servername.infra.rust-lang.org
     ```
 

--- a/src/infra/docs/crater-agents.md
+++ b/src/infra/docs/crater-agents.md
@@ -25,7 +25,7 @@ The agent is managed by the `container-crater-agent.service` systemd unit. That
 means it's possible to start, stop and restart it with the usual systemctl
 commands:
 
-```
+```console
 systemctl stop container-crater-agent.service
 systemctl start container-crater-agent.service
 systemctl restart container-crater-agent.service
@@ -36,7 +36,7 @@ systemctl restart container-crater-agent.service
 Logs of the agents are forwarded and collected by journald. To see them you can
 use journalctl:
 
-```
+```console
 journalctl -u container-crater-agent.service
 ```
 
@@ -46,7 +46,7 @@ The container is updated automatically every 5 minutes (provided a newer image
 is present). If you need to update them sooner you can manually start the
 updater service by running this command:
 
-```
+```console
 systemctl start docker-images-update.service
 ```
 

--- a/src/infra/docs/dev-desktop-github-app.md
+++ b/src/infra/docs/dev-desktop-github-app.md
@@ -48,9 +48,8 @@ In our case, we just abort (`exit(0)`) for everything but `get`, as we regenerat
 
 The actual arguments are passed via stdin and usually look like
 
-```
+```console
 protocol=https
 host=github.com
 path=your_repo.git
 ```
-

--- a/src/infra/docs/dns.md
+++ b/src/infra/docs/dns.md
@@ -139,7 +139,7 @@ module "redirect_<IDENTIFIER>" {
 
 Once you made all the changes you can apply the configuration with:
 
-```
+```console
 terraform init
 terraform apply
 ```

--- a/src/infra/docs/ecs-services.md
+++ b/src/infra/docs/ecs-services.md
@@ -32,7 +32,7 @@ application).
 To restart an application, you can force a new deployment without actually
 pushing any new code beforehand. To do so, run this command:
 
-```
+```console
 aws ecs update-service --cluster rust-ecs-prod --service <service-name> --force-new-deployment
 ```
 
@@ -43,7 +43,7 @@ in the simpleinfra repository) with your [AWS credentials][aws-access] present
 in the shell. The script requires the name of the ECR container image
 repository as its first and only argument:
 
-```
+```console
 ./aws-rollback.py <image-repository-name>
 ```
 
@@ -65,20 +65,20 @@ For production applications it's recommended to setup automatic deployment.
 To manually deploy a local build you first need it to tag your built image
 with its ECR name:
 
-```
+```console
 docker tag <image-tag> 890664054962.dkr.ecr.us-west-1.amazonaws.com/<repository-name>:latest
 ```
 
 Then you can authenticate with ECR and push it:
 
-```
+```console
 $(aws ecr get-login --no-include-email --region us-west-1)
 docker push 890664054962.dkr.ecr.us-west-1.amazonaws.com/<repository-name>:latest
 ```
 
 Finally, you need to force a new deployment of the ECS service with:
 
-```
+```console
 aws ecs update-service --cluster rust-ecs-prod --service <service-name> --force-new-deployment
 ```
 
@@ -89,7 +89,7 @@ deployments from CI. To use it, ask a team member to setup AWS credentials in
 your repository, and then add this snippet to your workflow:
 
 
-```
+```yaml
 - name: Build the Docker image
   run: docker build -t deploy-image .
 

--- a/src/infra/docs/rust-bots.md
+++ b/src/infra/docs/rust-bots.md
@@ -9,7 +9,7 @@
 
 First, edit `sudo vim /etc/nginx/nginx.conf` to edit the nginx configuration to add the domain.
 
-```
+```console
 server {
     listen 443 ssl;
     listen [::]:443 ssl;

--- a/src/infra/guidelines/static-websites.md
+++ b/src/infra/guidelines/static-websites.md
@@ -7,29 +7,29 @@ and how to setup one.
 ## Requirements for hosting websites
 
 * **The website must be managed by a Rust team, or be officially affiliated with
-  the project.**  
+  the project.**
   The infrastructure team has finite resources and we can't offer hosting for
   community projects.
 * **The website’s content and build tooling must be hosted on a GitHub
   repository in either the [rust-lang](https://github.com/rust-lang) or
-  [rust-lang-nursery](https://github.com/rust-lang-nursery) organizations.**  
+  [rust-lang-nursery](https://github.com/rust-lang-nursery) organizations.**
   The infrastructure team must be able to rebuild the website content at any
   time (for example if we need to switch hosting), and having it hosted on a
   GitHub repository inside infra-managed organizations is the best way for us
   to ensure that. Even though we'd prefer for all the repositories to be public
   it's not a requirement.
-* **The website must be built and deployed with a CI service.**  
+* **The website must be built and deployed with a CI service.**
   We have custom tooling built around hosting static websites on our infra, and
   at the moment they work with Travis CI and Azure Pipelines. If you need
   different CI services ask us in advance and we'll adapt the tooling to your
   provider of choice.
 * **The website must reach an A+ grade on the
-  [Mozilla Observatory](https://observatory.mozilla.org/).**  
+  [Mozilla Observatory](https://observatory.mozilla.org/).**
   Browsers have multiple security features toggleable only through HTTP
   response headers, and those features enhance users' privacy and prevent
   exploits from working. An A+ grade on the Observatory indicates all the
   important headers are correctly set.
-* **The website must be hosted on platforms vetted by the infra team.**  
+* **The website must be hosted on platforms vetted by the infra team.**
   We recommend either GitHub Pages or Amazon S3 (in the rust-lang AWS account)
   as the hosting and CloudFront as the CDN, but if you need other platforms
   that's good as long as we consider them secure and reliable.
@@ -120,7 +120,7 @@ To setup the deploy key you need to be an administrator on the repository,
 clone the [simpleinfra](https://github.com/rust-lang/simpleinfra) repository
 and run this command:
 
-```
+```console
 $ cargo run --bin setup-deploy-keys rust-lang/repo-name
 ```
 

--- a/src/infra/policies/broken-nightlies.md
+++ b/src/infra/policies/broken-nightlies.md
@@ -26,7 +26,7 @@ Once any member of the infra team decides to roll back a nightly under this
 policy we will roll back to the most recent working nightly. The roll back has
 to fix installing the nightly with rustup:
 
-```
+```console
 $ rustup toolchain install nightly
 ```
 

--- a/src/infra/service-infrastructure.md
+++ b/src/infra/service-infrastructure.md
@@ -71,7 +71,9 @@ One-off performance runs can done by addressing the
 ([bot user account](https://github.com/rust-timer)). You can trigger the
 necessary try-build and queue a perf run by saying
 
-    @bors try @rust-timer queue
+```console
+@bors try @rust-timer queue
+```
 
 (Technically, the requirement is that the `queue` command finishes executing prior
 to the try build completing successfully.)

--- a/src/release/crater.md
+++ b/src/release/crater.md
@@ -17,7 +17,7 @@ $STABLE is e.g. 1.39.0 (the stable release)
 $BETA is beta-YYYY-MM-DD, get the date by looking at https://static.rust-lang.org/manifests.txt and
 get the date of the most recent channel-rust-beta.toml.
 
-```
+```console
 @craterbot run name=beta-$BETA_VERSION start=$STABLE end=$BETA mode=build-and-test cap-lints=warn p=10
 @craterbot run name=beta-rustdoc-$BETA_VERSION start=$STABLE end=$BETA mode=rustdoc cap-lints=warn p=5
 ```
@@ -74,7 +74,7 @@ crater run a couple times you get a pretty good sense of what is spurious and wh
 You can run crater on just a single crate by doing something like this (at least, as of now).
 Note that this will download several gigabytes (on first use) and requires Docker to be running.
 
-```
+```console
 git clone https://github.com/rust-lang/crater
 cd crater
 cargo run -- prepare-local

--- a/src/release/issue-triaging.md
+++ b/src/release/issue-triaging.md
@@ -67,7 +67,7 @@ Users with write access should change the labels directly to avoid sending a not
 
 For example:
 
-```
+```console
 @rustbot label +T-compiler +C-bug +A-linkage +O-macos -needs-triage
 ```
 

--- a/src/release/process.md
+++ b/src/release/process.md
@@ -16,7 +16,7 @@ need to invoke the script *multiple times* until everything is setup correctly.
 it finishes, you have to watch the logs. When the build finishes, a line like
 this will appear in the logs:
 
-```
+```console
 Phase complete: UPLOAD_ARTIFACTS State: SUCCEEDED
 ```
 
@@ -42,7 +42,7 @@ pre-release testing period).
 
 Run this command from the [rust-lang/release-team] repository[^auth]:
 
-```
+```console
 ./scripts/start-release.py update-rust-branches
 ```
 
@@ -59,7 +59,7 @@ following changes:
 
   - If the release notes PR was merged:
 
-    ```
+    ```console
     git checkout origin/master -- RELEASES.md
     ```
 
@@ -84,7 +84,7 @@ going to finish soon (use your judgement here), you can "yield"
 priority to the stable release PR by going into that PR and typing this
 comment:
 
-> @bors retry  
+> @bors retry
 > Yield priority to the stable release.
 
 ### `beta` PR
@@ -94,7 +94,7 @@ changes:
 
 * Run this command and create a **separate commit** with just its output:
 
-  ```
+  ```console
   ./x.py run replace-version-placeholder
   ```
 
@@ -107,7 +107,7 @@ Self-approve the PR with `r+ rollup=never p=10`.
 After the `stable` PR is merged you'll need to start the pre-release. Run this command from the
 [rust-lang/release-team] repository[^auth]:
 
-```
+```console
 ./scripts/start-release.py publish-rust-dev-stable YYYY-MM-DD
 ```
 
@@ -129,7 +129,7 @@ Send a PR to the master branch to:
 
 - Run this to update the bootstrap compiler to the beta you created yesterday:
 
-  ```
+  ```console
   ./x.py run src/tools/bump-stage0
   ```
 
@@ -137,7 +137,7 @@ Send a PR to the master branch to:
   compilation attributes. You can find all of them by installing [ripgrep] and
   running this command:
 
-  ```
+  ```console
   rg '#!?\[.*\(bootstrap' -t rust -t toml
   ```
 
@@ -157,7 +157,7 @@ Send a PR to the master branch to:
 
 - Ensure there are no new warnings or Clippy lints affecting the codebase:
 
-  ```
+  ```console
   ./x clippy ci
   ```
 
@@ -176,7 +176,7 @@ start the release process earlier enough to hit the time you planned.
 To start the release, Run this command in the [rust-lang/release-team]
 repository[^auth]:
 
-```
+```console
 ./scripts/start-release.py publish-rust-prod-stable
 ```
 
@@ -192,7 +192,7 @@ announce the release on social media. Finally, bask in your success 🎉
 Send a PR to the beta branch updating the stage0 to the stable release you
 published:
 
-```
+```console
 ./x run src/tools/bump-stage0
 ```
 
@@ -203,7 +203,7 @@ PR on the `stable` branch of the [rust-lang/rust] repository. Once the commit
 is merged, [authenticate with AWS][awscli] and run this command in the
 [rust-lang/release-team] repository:
 
-```
+```console
 ./scripts/start-release.py publish-rust-dev-stable-rebuild
 ```
 

--- a/src/release/release-notes.md
+++ b/src/release/release-notes.md
@@ -46,7 +46,7 @@ The release note text is automatically pulled in subsequent steps, and should us
 
 Stabilized APIs and Const Stabilized APIs should both be formatted roughly as follows:
 
-```
+```md
 - [`std::ptr::null_mut`](https://doc.rust-lang.org/std/ptr/fn.null_mut.html)
 ```
 
@@ -149,7 +149,7 @@ adding themselves to the
 When creating a relnotes PR and release blog post, please ping this
 notification group via
 
-```
+```console
 @rustbot ping relnotes-interest-group
 ```
 

--- a/src/release/rollups.md
+++ b/src/release/rollups.md
@@ -37,9 +37,9 @@ queue has been merged.
 
 2. Run the following command in the pull request thread:
 
-    ```
+    ```console
     @bors r+ rollup=never p=5
-    ````
+    ```
 
 3. If the rollup fails, use the logs rust-log-analyzer
    provides to bisect the failure to a specific PR and do

--- a/src/triagebot/transfer.md
+++ b/src/triagebot/transfer.md
@@ -10,7 +10,7 @@ To transfer an issue to another repository, enter a comment with the form:
 
 It is recommended to also include a comment explaining why you are transferring. For example:
 
-```
+```text
 Transferring to rust-lang/cargo since this is an issue with how cargo
 implements diagnostic reports.
 


### PR DESCRIPTION
I noticed that we have a command `mdbook test`, I have run it and discovered a massive quantity of linting errors.

I did a random visual check and adding the `console` parameter to all these quoted texts does not seems to change anything but fixes the tests.

So maybe the question is, are we interested in fixing these tests? Are we using tests here anyway?

thanks for sharing an opinion :)

Note: I left out from this patch some lints failures because they involve Rust code and I suspect it's just not linting

[Rendered](https://github.com/apiraino/rust-forge/blob/fix-tests-round-1/src/crates-io/db-maintenance.md)