### PR TITLE
Fix some warning blocks that contain Markdown

### DIFF
--- a/src/infra/docs/bors/queue-resync.md
+++ b/src/infra/docs/bors/queue-resync.md
@@ -3,6 +3,7 @@
 bors queue page: <https://bors.rust-lang.org/queue/rust>.
 
 <div class="warning">
+
 **WARNING**: You should only do this if you have bors `r+` permissions on the
 rust-lang/rust repo. Please do not synchronize if you do not have `r+` permissions
 even if you have write access to the repo, as you will be unable to perform the
@@ -14,6 +15,7 @@ be recollected, and 15 minutes after that to kick out PRs that should not be in
 the tree.
 
 **DO NOT CLICK THIS BUTTON IF YOU ARE NOT ABLE TO HANDLE THE CLEANUP.**
+
 </div>
 
 Sometimes you have to do a bors queue sync for various reasons. This is not

--- a/src/release/issue-triaging.md
+++ b/src/release/issue-triaging.md
@@ -182,7 +182,9 @@ Anything related to the compiler implementation, such as diagnostics and ICEs.
 ### Creating labels
 
 <div class="warning">
+
 Triagebot needs to support `@rustbot label: xxx` usages terminated with a period or whitespace (as inline invocation), so the label name must consist of only alphanumeric or hyphen (`-`) or underscore (`_`) characters.
+
 </div>
 
 - Check existing labels to make sure you're not duplicating them.


### PR DESCRIPTION
Similar to https://github.com/rust-lang/rustc-dev-guide/pull/2446.

Content inside of an HTML element only gets interpreted as Markdown (as opposed to HTML) if its separated by line breaks from the HTML tags.

| Before | After |
|---|---|
| <img width="983" height="71" alt="Screenshot 2025-08-24 at 20-06-30 Issue Triaging - Rust Forge" src="https://github.com/user-attachments/assets/74522456-8116-4b65-b02d-cee6a521f789" /> | <img width="976" height="64" alt="Screenshot 2025-08-24 at 20-06-44 Issue Triaging - Rust Forge" src="https://github.com/user-attachments/assets/da2d66af-6258-43c6-bbbf-197c89dbdad3" /> |
| <img width="972" height="185" alt="Screenshot 2025-08-24 at 20-08-12 Fixing bors queue - Rust Forge" src="https://github.com/user-attachments/assets/373943e4-50be-4419-890f-66ac6dd8bd1a" /> | <img width="965" height="196" alt="Screenshot 2025-08-24 at 20-08-26 Fixing bors queue - Rust Forge" src="https://github.com/user-attachments/assets/43fbdfab-30a8-433a-acab-5f9ef29507f0" /> |

