### PR TITLE
clarify blogs approval process

### DIFF
--- a/src/platforms/blogs.md
+++ b/src/platforms/blogs.md
@@ -87,7 +87,8 @@ Typical subjects for inside Rust blog posts include:
 
 ## Approval process
 
-For both the inside Rust and main blogs, we require an approval from:
+For both the inside Rust and main blogs, we require at least one approval.
+The approver should belong to one of the following groups:
 
 * Any team lead (top level or not)
 * Any leadership council member


### PR DESCRIPTION
This PR clarifies that the list is an OR, instead of an AND.

As discussed in [#t-infra > meeting 2025-08-25 @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/meeting.202025-08-25/near/536033048) this isn't clear.

[Rendered](https://github.com/marcoieni/rust-forge/blob/clarify-blogs-approval/src/platforms/blogs.md)