### PR TITLE
Add documentation for `type="content"` in triagebot mentions

### DIFF
--- a/src/triagebot/mentions.md
+++ b/src/triagebot/mentions.md
@@ -10,12 +10,17 @@ Mentions are triggered automatically when a PR is opened (or new changes are pus
 ## Configuration
 
 To enable mentions, add entries to the `[mentions]` table in `triagebot.toml`.
-Each key in the table should be a path in the repo.
-Triagebot will check for modifications to any file that **starts with** the given path.
+Each key in the table should either be a path in the repo or should be a string (when `type="content"`).
+
+Triagebot will check for modifications:
+ - to any file that **starts with** the given path when `type="filename"` (the default)
+ - or to any modified lines of the PR when `type="content"`
+
 For example, `library/std` would match anything under the `library/std` directory like `library/std/src/process.rs`.
 
 There are two optional values that can be specified in the table:
 
+* `type` --- Specifies the matching type that must be satisfied, either `filename` (the default) or `content`.
 * `cc` --- A list of strings of users to ping.
   They should start with `@` like `@ehuss` or `@rust-lang/clippy`.
   If this is not specified, nobody will be pinged.
@@ -34,6 +39,10 @@ rustdoc-json-types is a **public** (although nightly-only) API.
 If possible, consider changing `src/librustdoc/json/conversions.rs`;
 otherwise, make sure you bump the `FORMAT_VERSION` constant.
 """
+
+[mentions."#[rustc_attr]"]
+type = "content"
+cc = ["@someone"]
 ```
 
 ## Implementation


### PR DESCRIPTION
Related to https://github.com/rust-lang/triagebot/pull/2171
r? Kobzol

[Rendered](https://github.com/Urgau/rust-forge/blob/triagebot-mentions-content/src/triagebot/mentions.md)