### PR TITLE
Add documentation for triagebot `check-commits = "uncanonicalized"`

### DIFF
--- a/src/triagebot/issue-links.md
+++ b/src/triagebot/issue-links.md
@@ -21,9 +21,21 @@ This feature is enabled on a repository by having a `[issue-links]` table in `tr
 
 ### Without commits checking
 
+Some repositories may not need, or may prefer not, to warn about issue links in commit messages. This behavior can be disabled with the `check-commits` configuration option:
+
 ```toml
 [issue-links]
 check-commits = false # defaults to true
+```
+
+#### Only check uncanonicalized issue links
+
+For subtrees (or embedded repositories), it is recommended to still check for *uncanonicalized* issue links (e.g. `#132` instead of `rust-lang/cargo#123`). 
+This prevents links from resolving to the wrong repository when the subtree is merged upstream while still allowing issue links in commits.
+
+```toml
+[issue-links]
+check-commits = "uncanonicalized" # for subtrees
 ```
 
 ## Implementation


### PR DESCRIPTION
Related to https://github.com/rust-lang/triagebot/pull/2175
r? Kobzol

[Rendered](https://github.com/Urgau/rust-forge/blob/triagebot-uncanonicalized-issue-links/src/triagebot/issue-links.md)