### PR TITLE
split overlong sentence

### DIFF
--- a/src/compiler/index.md
+++ b/src/compiler/index.md
@@ -2,8 +2,8 @@
 Rust's compiler team are responsible for maintaining the Rust compiler, improving its performance
 and considering the stabilization of compiler features.
 
-We use the Forge to document the team's processes, policies and working practices, if you'd like to
-read about how the compiler works and instructions on how to set up a development environment,
+We use the Forge to document the team's processes, policies, and working practices.
+If you'd like to read about how the compiler works and instructions on how to set up a development environment,
 you're looking for the [rustc-dev-guide](https://rustc-dev-guide.rust-lang.org/).
 
 <!--


### PR DESCRIPTION
Sentence also did not read well, so it needed the period.