### PR TITLE
nittpick: avoid acronym that can refer to another one

### DIFF
--- a/src/policies/llm-usage.md
+++ b/src/policies/llm-usage.md
@@ -303,7 +303,7 @@ In most cases the output is "trivial" (see above under ⚠️), but regardless, 
 This policy is not set in stone, and we can evolve it as we gain more experience working with LLMs.
 
 Minor changes, such as typo fixes, only require a normal PR approval.
-Major changes, such as adding a new rule or canceling an existing rule, require a successful MCP (2 approvals and no concerns) from each team that ratified the policy.
+Major changes, such as adding a new rule or canceling an existing rule, require a successful [MCP (Major Change Proposal)](../compiler/proposals-and-stabilization.html#proposals) (2 approvals and no concerns) from each team that ratified the policy.
 Changes to the guidance in the rustc-dev-guide have no special requirements for modification.
 
 This policy can be dissolved in a few ways:


### PR DESCRIPTION
In a context of LLM, MCP could stand for Model Context Protocol (which doesn't make sense in this sentence)

I was not aware of this acronym, i put the full name to be more explicit and a link to the internal documentation to have the full meaning

[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/policies/llm-usage.md)