### PR TITLE
Add a mention about project goals

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -85,6 +85,7 @@
     - [Leadership Council](./governance/council.md)
     - [Moderation](./governance/moderation.md)
     - [Project groups](./governance/project-groups.md)
+    - [Project goals](./governance/project-goals.md)
 - [Policies](./policies/index.md)
     - [Crate ownership policy](./policies/crate-ownership.md)
     - [LLM usage policy](./policies/llm-usage.md)

--- a/src/governance/project-goals.md
+++ b/src/governance/project-goals.md
@@ -1,0 +1,30 @@
+# Project goals
+
+## Introduction
+
+Project goals is a program we run to help people from inside or outside the project proposing medium to big changes by providing resources and help.
+
+Having a goal can help find some funding: the Project [lists the goals that are looking for funding](https://rust-lang.github.io/goals/2026/funding.html), and the funding team and [RCN] are also places where potential funding partners can look for goals of interest to them.
+
+This page only provides a quick overview; full documentation is available at [this link][goals-docs].
+
+## Structure and coordination
+
+Get in contact with the [goals team] on [Zulip][zulip-t-goals].
+
+Project goal proposals are tracked on [GitHub][goals-issue-tracker].
+
+## Funding
+
+Project goal proponents can ask to apply for funding. See [documentation][goals-funding] for more information.
+
+For more informations about how to get funding, get in contact with the [funding team] on [Zulip][zulip-t-funding].
+
+[goals team]: https://rust-lang.org/governance/teams/#team-goals
+[goals-docs]: https://rust-lang.github.io/goals/index.html
+[funding team]: https://rust-lang.org/governance/teams/launching-pad/#team-funding
+[zulip-t-funding]: https://rust-lang.zulipchat.com/#narrow/stream/funding
+[goals-issue-tracker]: https://github.com/rust-lang/goals/issues
+[zulip-t-goals]: https://rust-lang.zulipchat.com/#narrow/channel/435869-goals
+[goals-funding]: https://rust-lang.github.io/goals/about/goal-format.html#funding
+[RCN]: https://rustfoundation.org/rust-commercial-network


### PR DESCRIPTION
As I mentioned on [Zulip](https://rust-lang.zulipchat.com/#narrow/channel/478266-goals.2Fmeta/topic/Where.20is.20the.20PG.20documentation.3F/near/615012637), I didn't find anywhere a reference to project goals, so I thought about adding a quick reference with links to redirect people to the right places.

I know they wanted to move the docs from [github.io to a subdomain under rust-lang.org](https://github.com/rust-lang/goals/issues/753). Links in this page can be updated when this will happen.

cc: @lqd (for project goals) and @Kobzol (for t-funding)

Happy to take suggestions about this text! I quickly drafted this driven just by my instinct xD

thanks!

[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/governance/project-goals.md)