### PR TITLE
Update the Project Goals website

### DIFF
--- a/src/governance/project-goals.md
+++ b/src/governance/project-goals.md
@@ -4,7 +4,7 @@
 
 Project goals is a program we run to help people from inside or outside the project proposing medium to big changes by providing resources and help.
 
-Having a goal can help find some funding: the Project [lists the goals that are looking for funding](https://rust-lang.github.io/goals/2026/funding.html), and the funding team and [RCN] are also places where potential funding partners can look for goals of interest to them.
+Having a goal can help find some funding: the Project [lists the goals that are looking for funding](https://goals.rust-lang.org/2026/funding.html), and the funding team and [RCN] are also places where potential funding partners can look for goals of interest to them.
 
 This page only provides a quick overview; full documentation is available at [this link][goals-docs].
 
@@ -21,10 +21,10 @@ Project goal proponents can ask to apply for funding. See [documentation][goals-
 For more informations about how to get funding, get in contact with the [funding team] on [Zulip][zulip-t-funding].
 
 [goals team]: https://rust-lang.org/governance/teams/#team-goals
-[goals-docs]: https://rust-lang.github.io/goals/index.html
+[goals-docs]: https://goals.rust-lang.org/index.html
 [funding team]: https://rust-lang.org/governance/teams/launching-pad/#team-funding
 [zulip-t-funding]: https://rust-lang.zulipchat.com/#narrow/stream/funding
 [goals-issue-tracker]: https://github.com/rust-lang/goals/issues
 [zulip-t-goals]: https://rust-lang.zulipchat.com/#narrow/channel/435869-goals
-[goals-funding]: https://rust-lang.github.io/goals/about/goal-format.html#funding
+[goals-funding]: https://goals.rust-lang.org/about/goal-format.html#funding
 [RCN]: https://rustfoundation.org/rust-commercial-network


### PR DESCRIPTION
It's now at: https://goals.rust-lang.org/

[Rendered](https://github.com/rust-lang/rust-forge/blob/main/src/governance/project-goals.md)